### PR TITLE
refactor _common_kwargs to OmegaRuntime

### DIFF
--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -28,7 +28,9 @@ OMEGA_NOTEBOOK_COLLECTION = 'ipynb'
 OMEGA_RESULT_BACKEND = 'amqp'
 #: the celery configurations
 OMEGA_CELERY_CONFIG = {
-    'CELERY_ACCEPT_CONTENT': ['pickle', 'json', 'msgpack', 'yaml'],
+    'CELERY_ACCEPT_CONTENT': ['pickle', 'json'],
+    'CELERY_TASK_SERIALIZER': 'pickle',
+    'CELERY_RESULT_SERIALIZER': 'pickle',
     'BROKER_URL': OMEGA_BROKER,
     'CELERY_RESULT_BACKEND': OMEGA_RESULT_BACKEND,
     'CELERY_ALWAYS_EAGER': False if 'OMEGA_BROKER' in os.environ else True,

--- a/omegaml/runtimes/jobproxy.py
+++ b/omegaml/runtimes/jobproxy.py
@@ -31,10 +31,6 @@ class OmegaJobProxy(object):
         self.jobname = jobname
         self.runtime = runtime
 
-    @property
-    def _common_kwargs(self):
-        return dict()
-
     def run(self, **kwargs):
         """
         run the job
@@ -42,11 +38,11 @@ class OmegaJobProxy(object):
         :return: the result
         """
         job_run = self.runtime.task('omegaml.notebook.tasks.run_omegaml_job')
-        return job_run.delay(self.jobname, **self._common_kwargs, **kwargs)
+        return job_run.delay(self.jobname, **self.runtime._common_kwargs, **kwargs)
 
     def schedule(self, **kwargs):
         """
         schedule the job
         """
         job_run = self.runtime.task('omegaml.notebook.tasks.schedule_omegaml_job')
-        return job_run.delay(self.jobname, **self._common_kwargs, **kwargs)
+        return job_run.delay(self.jobname, **self.runtime._common_kwargs, **kwargs)

--- a/omegaml/runtimes/mixins/gridsearch.py
+++ b/omegaml/runtimes/mixins/gridsearch.py
@@ -1,12 +1,8 @@
 class GridSearchMixin(object):
-    @property
-    def _common_kwargs(self):
-        return dict(pure_python=self.pure_python)
-
     def gridsearch(self, Xname, Yname, parameters=None, pure_python=False, **kwargs):
         gs_task = self.runtime.task('omegaml.tasks.omega_gridsearch')
         Xname = self._ensure_data_is_stored(Xname, prefix='_fitX')
         if Yname is not None:
             Yname = self._ensure_data_is_stored(Yname, prefix='_fitY')
         return gs_task.delay(self.modelname, Xname, Yname, parameters=parameters,
-                             **self._common_kwargs, **kwargs)
+                             **self.runtime._common_kwargs, **kwargs)

--- a/omegaml/runtimes/mixins/modelmixin.py
+++ b/omegaml/runtimes/mixins/modelmixin.py
@@ -11,10 +11,6 @@ logger = logging.getLogger(__file__)
 
 
 class ModelMixin(object):
-    @property
-    def _common_kwargs(self):
-        return dict(pure_python=self.pure_python)
-
     def fit(self, Xname, Yname=None, **kwargs):
         """
         fit the model
@@ -36,7 +32,7 @@ class ModelMixin(object):
         if Yname is not None:
             Yname = self._ensure_data_is_stored(Yname, prefix='_fitY')
         return omega_fit.delay(self.modelname, Xname, Yname,
-                               **self._common_kwargs, **kwargs)
+                               **self.runtime._common_kwargs, **kwargs)
 
     def partial_fit(self, Xname, Yname=None, **kwargs):
         """
@@ -59,7 +55,7 @@ class ModelMixin(object):
         if Yname is not None:
             Yname = self._ensure_data_is_stored(Yname, prefix='_fitY')
         return omega_fit.delay(self.modelname, Xname, Yname,
-                               **self._common_kwargs, **kwargs)
+                               **self.runtime._common_kwargs, **kwargs)
 
     def transform(self, Xname, rName=None, **kwargs):
         """
@@ -77,7 +73,7 @@ class ModelMixin(object):
         Xname = self._ensure_data_is_stored(Xname)
         return omega_transform.delay(self.modelname, Xname,
                                      rName=rName,
-                                     **self._common_kwargs, **kwargs)
+                                     **self.runtime._common_kwargs, **kwargs)
 
     def fit_transform(self, Xname, Yname=None, rName=None, **kwargs):
         """
@@ -100,7 +96,7 @@ class ModelMixin(object):
             Yname = self._ensure_data_is_stored(Yname)
         return omega_fit_transform.delay(self.modelname, Xname, Yname,
                                          rName=rName, transform=True,
-                                         **self._common_kwargs, **kwargs)
+                                         **self.runtime._common_kwargs, **kwargs)
 
     def predict(self, Xpath_or_data, rName=None, **kwargs):
         """
@@ -117,7 +113,7 @@ class ModelMixin(object):
         omega_predict = self.runtime.task('omegaml.tasks.omega_predict')
         Xname = self._ensure_data_is_stored(Xpath_or_data)
         return omega_predict.delay(self.modelname, Xname, rName=rName,
-                                   **self._common_kwargs, **kwargs)
+                                   **self.runtime._common_kwargs, **kwargs)
 
     def predict_proba(self, Xpath_or_data, rName=None, **kwargs):
         """
@@ -135,7 +131,7 @@ class ModelMixin(object):
             'omegaml.tasks.omega_predict_proba')
         Xname = self._ensure_data_is_stored(Xpath_or_data)
         return omega_predict_proba.delay(self.modelname, Xname, rName=rName,
-                                         **self._common_kwargs, **kwargs)
+                                         **self.runtime._common_kwargs, **kwargs)
 
     def score(self, Xname, yName, rName=None, **kwargs):
         """
@@ -154,7 +150,7 @@ class ModelMixin(object):
         Xname = self._ensure_data_is_stored(Xname)
         yName = self._ensure_data_is_stored(yName)
         return omega_score.delay(self.modelname, Xname, yName, rName=rName,
-                                 **self._common_kwargs, **kwargs)
+                                 **self.runtime._common_kwargs, **kwargs)
 
     def decision_function(self, Xname, rName=None, **kwargs):
         """
@@ -171,7 +167,7 @@ class ModelMixin(object):
         omega_decision_function = self.runtime.task('omegaml.tasks.omega_decision_function')
         Xname = self._ensure_data_is_stored(Xname)
         return omega_decision_function.delay(self.modelname, Xname, rName=rName,
-                                             **self._common_kwargs, **kwargs)
+                                             **self.runtime._common_kwargs, **kwargs)
 
     def _ensure_data_is_stored(self, name_or_data, prefix='_temp'):
         if is_dataframe(name_or_data):

--- a/omegaml/runtimes/modelproxy.py
+++ b/omegaml/runtimes/modelproxy.py
@@ -6,11 +6,11 @@ from uuid import uuid4
 import six
 
 from omegaml.util import is_dataframe, settings, is_ndarray, extend_instance
-logger = logging.getLogger(__file__)
+
+logger = logging.getLogger(__name__)
 
 
 class OmegaModelProxy(object):
-
     """
     proxy to a remote model in a celery worker
 
@@ -34,23 +34,20 @@ class OmegaModelProxy(object):
             print result.get()
     """
 
-#     Implementation note:
-#
-#     We decided to implement each method call explicitely in both
-#     this class (mixins) and the celery tasks. While it would be possible to
-#     implement a generic method and task that passes the method and
-#     arguments to be called, maintainability would suffer and the
-#     documentation would become very unspecific. We think it is much
-#     cleaner to have an explicit interface at the chance of missing
-#     features. If need should arise we can still implement a generic
-#     method call.
+    #     Implementation note:
+    #
+    #     We decided to implement each method call explicitely in both
+    #     this class (mixins) and the celery tasks. While it would be possible to
+    #     implement a generic method and task that passes the method and
+    #     arguments to be called, maintainability would suffer and the
+    #     documentation would become very unspecific. We think it is much
+    #     cleaner to have an explicit interface at the chance of missing
+    #     features. If need should arise we can still implement a generic
+    #     method call.
 
     def __init__(self, modelname, runtime=None):
         self.modelname = modelname
         self.runtime = runtime
-        self.pure_python = getattr(settings(), 'OMEGA_FORCE_PYTHON_CLIENT',
-                                   False)
-        self.pure_python = self.pure_python or self._client_is_pure_python()
         self.apply_mixins()
 
     def apply_mixins(self):
@@ -60,14 +57,3 @@ class OmegaModelProxy(object):
         from omegaml import defaults
         for mixin in defaults.OMEGA_RUNTIME_MIXINS:
             extend_instance(self, mixin)
-
-    def _client_is_pure_python(self):
-        try:
-            import pandas as pd
-            import numpy as np
-            import sklearn
-        except Exception as e:
-            logging.getLogger().info(e)
-            return True
-        else:
-            return False

--- a/omegaml/tests/test_jobs.py
+++ b/omegaml/tests/test_jobs.py
@@ -164,7 +164,8 @@ class JobTests(TestCase):
 
         assert_pending()
         # -- run by the periodic task. note we pass now= as to simulate a time
-        om.runtime.task('omegaml.notebook.tasks.execute_scripts').run(now=trigger['run-at'])
+        kwargs = dict(now=trigger['run-at'], **om.runtime._common_kwargs)
+        om.runtime.task('omegaml.notebook.tasks.execute_scripts').apply_async(kwargs=kwargs).get()
         assert_ok(event=trigger['event'])
         # -- it should be pending again
         assert_pending()


### PR DESCRIPTION
This refactors _common_kwargs logic from XYProxy implementations to OmegaRuntime, rendering the implementation consistent and ensure the kwargs are always sent by the runtime, not by the choice of the proxy.