### PR TITLE
Enable client api

### DIFF
--- a/omegaml/client/userconf.py
+++ b/omegaml/client/userconf.py
@@ -19,7 +19,7 @@ def get_user_config_from_api(api_auth, api_url=None, requested_userid=None, view
         query.append('view={}'.format(int(view)))
     api_url += '?' + '&'.join(query)
     # -- setup appropriate client API
-    if defaults.OMEGA_RESTAPI_URL.startswith('http'):
+    if api_url.startswith('http'):
         import requests
         server = requests
         server_kwargs = dict(auth=api_auth)

--- a/omegaml/tests/test_sklext.py
+++ b/omegaml/tests/test_sklext.py
@@ -16,19 +16,20 @@ class OnlinePipelineTests(TestCase):
         # define an online pipeline
         piple = OnlinePipeline([
             ('scale', StandardScaler()),
-            ('clf', SGDRegressor(random_state=5, shuffle=False, verbose=True, n_iter=1)),
+            ('clf', SGDRegressor(random_state=5, shuffle=False, verbose=True, max_iter=10)),
         ])
         # define an offline pipelines
         pipl = Pipeline([
             ('scale', StandardScaler()),
-            ('clf', SGDRegressor(random_state=5, shuffle=False, verbose=True, n_iter=1)),
+            ('clf', SGDRegressor(random_state=5, shuffle=False, verbose=True, max_iter=20)),
         ])
         # generate some data
         X, y = make_regression(100, 100, random_state=42)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.33, random_state=42)
         # fit, predict in an online manner
-        piple.partial_fit(X_train[0:30], y_train[0:30])
-        piple.partial_fit(X_train[30:], y_train[30:])
+        for i in range(100):
+            piple.partial_fit(X_train[0:30], y_train[0:30])
+            piple.partial_fit(X_train[30:], y_train[30:])
         ye = piple.predict(X_test)
         # fit, predict in offline manner
         pipl.fit(X_train, y_train)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'pandas>=0.17.1',
         'numpy>=1.10.4',
         'scipy>=0.17.0',
-        'scikit-learn>=0.17.1',
+        'scikit-learn>=0.20',
         'PyYAML>=3.11',
         'flask-restplus>=0.12.1',
         'six>=1.11.0',


### PR DESCRIPTION
this enables the client api to the managed omegaml platform.

```
from omegaml.client.userconf import get_omega_from_apikey
om = get_omega_from_apikey(userid='USER', apikey='APIKEY', api_url='platform URI')
# om is now instantiated to the remote db & runtime
```

