### PR TITLE
Promotion api

### DIFF
--- a/docs/source/guide/buckets.rst
+++ b/docs/source/guide/buckets.rst
@@ -1,0 +1,73 @@
+Multiple environments
+=====================
+
+omega|ml provides three concepts to work with multiple environments, each focussed on a specific need.
+
+* :code:`context` - a context provides a completely seperate environment, where all datasets, models,
+  jobs as well as the runtime is distinct from any other other context. Think of this is the equivalent
+  of a seperate account.
+
+* :code:`buckets` - a bucket is a logical subset of a context. It utilizes the same database and the
+  same runtime as any other bucket within the same context. Think of this a a top-level folder in
+  an other-wise shared environment.
+
+* :code:`runtime routing` - tasks submitted to the runtime can specify resource requirements, which
+  effectively route tasks to different workers. Multiple contexts can use the same runtime resources.
+  Think of this as compute cluster segregation e.g. by client or project.
+
+Working with Contexts
+---------------------
+
+omega|ml contexts are created by calling the :code:`om.setup()` function, returning a configured
+:code:`Omega()` instance:
+
+.. code::
+
+    # development environment
+    om_dev = om.setup(mongo_url=...., celeryconf=....)
+    # production environment
+    om_prod = om.setup(mongo_url=...., celeryconf=....)
+
+
+Working with Buckets
+--------------------
+
+Each :code:`Omega` instance is configured to a particular bucket, the default being :code:`omega`. To
+get an instantance configured for an other bucket use:
+
+.. code:: python
+
+    om_foo = om['mybucket']
+
+Buckets are an easy built-in way to separate environments, projects and users. For example,
+
+.. code:: python
+
+    # an environment for user1
+    om_user1 = om['user1']
+    # an environment for project_a
+    om_prjA = om['projec_a']
+    # development
+    om_dev = om['dev']
+    # production
+    om_prod = om['prod']
+    # etc.
+
+
+Promoting objects between contexts and environments
+---------------------------------------------------
+
+Object promotion copies objects from one context to another, more specifically from one bucket to another bucket.
+
+
+.. note::
+
+    Promoition is more than a simple copy: Some objects may require conditions to be met
+    (e.g. a model must be trained) before the promotion works. The default implementation
+    of object promotion does not impose any conditions and works as a copy/replace.
+
+
+.. code:: python
+
+    om_dev.datasets.promote('sales', om_prod.datasets)
+    om_dev.models.promote('sales-prediction', om_prod.models)

--- a/omegaml/backends/rawfiles.py
+++ b/omegaml/backends/rawfiles.py
@@ -22,7 +22,7 @@ class PythonRawFileBackend(BaseDataBackend):
     def get(self, name, version=-1, lazy=False, **kwargs):
         return self.data_store.metadata(name, **kwargs).gridfile
 
-    def put(self, obj, name, attributes=None, prefix=None, bucket=None, encoding=None, **kwargs):
+    def put(self, obj, name, attributes=None, encoding=None, **kwargs):
         self.data_store.drop(name, force=True)
         fn = self.data_store._get_obj_store_key(name, 'file')
         if self._is_path(obj):
@@ -35,8 +35,8 @@ class PythonRawFileBackend(BaseDataBackend):
                                collection_name=self.data_store.bucket)
         return self.data_store._make_metadata(
             name=name,
-            prefix=prefix or self.data_store.prefix,
-            bucket=bucket or self.data_store.bucket,
+            prefix=self.data_store.prefix,
+            bucket=self.data_store.bucket,
             kind=self.KIND,
             attributes=attributes,
             gridfile=gridfile).save()

--- a/omegaml/celery_util.py
+++ b/omegaml/celery_util.py
@@ -71,7 +71,8 @@ class OmegamlTask(EagerSerializationTaskMixin, Task):
         # TODO do some more intelligent caching, i.e. by client/auth
         if self._om is None:
             from omegaml import get_omega_for_task
-            self._om = get_omega_for_task(self)
+            bucket = self.request.kwargs.get('__bucket')
+            self._om = get_omega_for_task(self)[bucket]
         return self._om
 
     def get_delegate(self, name, kind='models'):

--- a/omegaml/mixins/store/promotion.py
+++ b/omegaml/mixins/store/promotion.py
@@ -1,0 +1,30 @@
+class PromotionMixin(object):
+    """
+    Promote objects from one bucket to another
+    """
+
+    def promote(self, name, other):
+        """
+        Promote object to another bucket.
+
+        This effectively copies the object. If the objects exists in the
+        target it will be replaced.
+
+        Args:
+            name: The name of the object
+            bucket: the bucket to promote to
+            other:
+
+        Returns:
+            The Metadata of the new object
+        """
+        if self.bucket == other.bucket and self.prefix == other.prefix:
+            raise ValueError('cannot promote to self')
+        # see if the backend supports explicit promotion
+        backend = self.get_backend(name)
+        if hasattr(backend, 'promote'):
+            return backend.promote(name, other)
+        # do default promotion
+        obj = self.get(name)
+        other.drop(name, force=True)
+        return other.put(obj, name)

--- a/omegaml/omega.py
+++ b/omegaml/omega.py
@@ -15,7 +15,8 @@ class Omega(object):
 
     """
 
-    def __init__(self, defaults=None, mongo_url=None, celeryconf=None, **kwargs):
+    def __init__(self, defaults=None, mongo_url=None, celeryconf=None, bucket=None,
+                 **kwargs):
         """
         Initialize the client API
 
@@ -37,16 +38,35 @@ class Omega(object):
         # celery and mongo configuration
         self.defaults = defaults or settings()
         self.mongo_url = mongo_url or self.defaults.OMEGA_MONGO_URL
+        self.bucket = bucket
         # setup storage locations
-        self.models = OmegaStore(mongo_url=self.mongo_url, prefix='models/', defaults=self.defaults)
-        self.datasets = OmegaStore(mongo_url=self.mongo_url, prefix='data/', defaults=self.defaults)
-        self._jobdata = OmegaStore(mongo_url=self.mongo_url, prefix='jobs/', defaults=self.defaults)
+        self.models = OmegaStore(mongo_url=self.mongo_url, bucket=bucket, prefix='models/', defaults=self.defaults)
+        self.datasets = OmegaStore(mongo_url=self.mongo_url, bucket=bucket, prefix='data/', defaults=self.defaults)
+        self._jobdata = OmegaStore(mongo_url=self.mongo_url, bucket=bucket, prefix='jobs/', defaults=self.defaults)
         # runtimes environments
-        self.runtime = OmegaRuntime(self, defaults=self.defaults, celeryconf=celeryconf)
+        self.runtime = OmegaRuntime(self, bucket=bucket, defaults=self.defaults, celeryconf=celeryconf)
         self.jobs = OmegaJobs(store=self._jobdata)
 
     def __repr__(self):
         return 'Omega()'.format()
+
+    def __getitem__(self, bucket):
+        """
+        return Omega instance configured for the given bucket
+
+        Args:
+            bucket (str): the bucket name. If it does not exist
+                  it gets created on first storage of an object.
+                  If bucket=None returns self.
+
+        Returns:
+            Omega instance configured for the given bucket
+        """
+        if bucket is None or self.bucket == bucket:
+            return self
+        return Omega(defaults=self.defaults,
+                     mongo_url=self.mongo_url,
+                     bucket=bucket)
 
 
 class OmegaDeferredInstance(object):
@@ -63,10 +83,12 @@ class OmegaDeferredInstance(object):
         self.base = base
         self.attribute = attribute
 
-    def setup(self):
-        self.omega = Omega()
-        self.initialized = True
-        return self
+    def setup(self, mongo_url=None, bucket=None, celeryconf=None):
+        omega = Omega(mongo_url=None, bucket=bucket, celeryconf=None)
+        if not self.initialized:
+            self.initialized = True
+            self.omega = omega
+        return omega
 
     def __getattr__(self, name):
         if self.base:
@@ -83,15 +105,15 @@ class OmegaDeferredInstance(object):
         return repr(self.omega)
 
 
-def setup():
+def setup(*args, **kwargs):
     """
     configure and return the omega client instance
     """
-    return _om.setup().omega
+    return _om.setup(*args, **kwargs)
 
 
 # dynamic lookup of Omega instance in a task context
-get_omega_for_task = lambda *args, **kwargs: _om
+get_omega_for_task = lambda *args, **kwargs: _om.setup(*args, **kwargs)
 
 # default instance
 # -- these are deferred instanced that is the actual Omega instance

--- a/omegaml/restapi/tests/test_api_buckets.py
+++ b/omegaml/restapi/tests/test_api_buckets.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+from omegaml import Omega
+from omegaml.client.auth import OmegaRestApiAuth
+from omegaml.restapi.app import app
+from omegaml.restapi.tests.test_api import OmegaRestApiTests
+from omegaml.restapi.tests.util import RequestsLikeTestClient
+
+
+class OmegaRestApiTestsWithBuckets(OmegaRestApiTests):
+    def setUp(self):
+        self.client = RequestsLikeTestClient(app)
+        self.om = Omega()['mybucket']
+        self.auth = OmegaRestApiAuth('user', 'pass')
+        self.clean()
+        self.clean('mybucket')
+
+    @property
+    def _headers(self):
+        return dict(bucket='mybucket')
+
+    def test_default_bucket_fails(self):
+        # put a model in the default bucket
+        om = Omega()
+        X = np.arange(10).reshape(-1, 1)
+        y = X * 2
+        # train model locally
+        clf = LinearRegression()
+        clf.fit(X, y)
+        result = clf.predict(X)
+        # store model in om
+        om.models.put(clf, 'regression')
+        resp = self.client.put('/api/v1/model/regression/predict', json={
+            'columns': ['v'],
+            'data': [dict(v=5)]
+        }, auth=self.auth, headers=self._headers)
+        # we expect an error because the model does not exist in the default bucket
+        self.assertEqual(resp.status_code, 500)
+        # see if we can get it to predict with the correct bucket (all other tests do this)
+        # -- note we simply remove the the 'bucket' header which reverts to the default
+        resp = self.client.put('/api/v1/model/regression/predict', json={
+            'columns': ['v'],
+            'data': [dict(v=5)]
+        }, auth=self.auth)
+        self.assertEqual(resp.status_code, 200)

--- a/omegaml/restapi/tests/util.py
+++ b/omegaml/restapi/tests/util.py
@@ -4,13 +4,13 @@ class RequestsLikeTestClient(object):
         self.client = app.test_client()
         self.headers = None
 
-    def make_client_kwargs(self, json=None, auth=None, **kwargs):
-        self.headers = headers = {}
+    def make_client_kwargs(self, json=None, auth=None, headers=None, **kwargs):
+        self.headers = headers or {}
         if auth:
             auth(self)
         if json:
             from json import dumps
-            headers.update({
+            self.headers.update({
                 'Accept': 'application/json',
                 'Content-Type': 'application/json'
             })

--- a/omegaml/runtimes/runtime.py
+++ b/omegaml/runtimes/runtime.py
@@ -48,9 +48,10 @@ class OmegaRuntime(object):
     omegaml compute cluster gateway 
     """
 
-    def __init__(self, omega, defaults=None, celeryconf=None):
+    def __init__(self, omega, bucket=None, defaults=None, celeryconf=None):
         self.omega = omega
         defaults = defaults or settings()
+        self.bucket = bucket
         self.pure_python = getattr(defaults, 'OMEGA_FORCE_PYTHON_CLIENT', False)
         self.pure_python = self.pure_python or self._client_is_pure_python()
         # initialize celery as a runtimes
@@ -72,7 +73,8 @@ class OmegaRuntime(object):
 
     @property
     def _common_kwargs(self):
-        common = dict(pure_python=self.pure_python)
+        common = dict(pure_python=self.pure_python,
+                      __bucket=self.bucket)
         common.update(self._task_default_kwargs)
         common.update(self._require_kwargs)
         return common

--- a/omegaml/store/base.py
+++ b/omegaml/store/base.py
@@ -676,8 +676,9 @@ class OmegaStore(object):
         """
         if kind:
             backend = self.get_backend_bykind(kind)
-            if not backend.supports(obj):
-                warnings.warn('')
+            if not backend.supports(obj, name, attributes=attributes, **kwargs):
+                objtype = str(type(obj))
+                warnings.warn('Backend {kind} does not support {objtype}'.format(**locals()))
             return backend
         for kind, backend_cls in six.iteritems(self.defaults.OMEGA_STORE_BACKENDS):
             backend = self.get_backend_bykind(kind)
@@ -693,7 +694,7 @@ class OmegaStore(object):
         """
         return self.get(*args, lazy=True, **kwargs)
 
-    def get(self, name, bucket=None, prefix=None, version=-1, force_python=False,
+    def get(self, name, version=-1, force_python=False,
             kind=None, **kwargs):
         """
         Retrieve an object
@@ -705,7 +706,7 @@ class OmegaStore(object):
         :return: an object, estimator, pipelines, data array or pandas dataframe
             previously stored with put()
         """
-        meta = self.metadata(name, bucket=None, prefix=None, version=version)
+        meta = self.metadata(name, version=version)
         if meta is None:
             return None
         if not force_python:

--- a/omegaml/tests/test_configs.py
+++ b/omegaml/tests/test_configs.py
@@ -58,10 +58,10 @@ class ConfigurationTests(TestCase):
         setup = om.setup
         with patch.object(defaults, 'OMEGA_MONGO_URL') as mock:
             defaults.OMEGA_MONGO_URL = 'foo'
-            om.setup()
+            om = om.setup()
             self.assertEqual(om.datasets.mongo_url, 'foo')
         # reset om.datasets to restored defaults
-        setup()
+        om = setup()
         self.assertNotEqual(om.datasets.mongo_url, 'foo')
         # now test we can change the default through config
         # we patch the actual api call to avoid having to set up the user db
@@ -79,10 +79,10 @@ class ConfigurationTests(TestCase):
             with patch.object(defaults, 'OMEGA_MONGO_URL') as mock:
                 from omegaml.client.userconf import get_omega_from_apikey
                 defaults.OMEGA_MONGO_URL = 'foo'
-                om.setup()
+                om = setup()
                 self.assertEqual(om.datasets.mongo_url, 'foo')
                 om = get_omega_from_apikey('foo', 'bar')
                 self.assertEqual(om.datasets.mongo_url, 'updated-foo')
-        setup()
+        om = setup()
         self.assertNotEqual(om.datasets.mongo_url, 'foo')
 

--- a/omegaml/tests/test_promotion.py
+++ b/omegaml/tests/test_promotion.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+
+from sklearn.linear_model import LinearRegression
+
+from omegaml import Omega
+from omegaml.mixins.store.promotion import PromotionMixin
+from omegaml.tests.util import OmegaTestMixin
+
+
+class PromotionMixinTests(OmegaTestMixin, TestCase):
+    def setUp(self):
+        om = self.om = Omega()
+        om.datasets.register_mixin(PromotionMixin)
+        om.models.register_mixin(PromotionMixin)
+        self.clean()
+        self.clean('prod')
+
+    def test_dataset_promotion(self):
+        om = self.om
+        prod = om['prod']
+        om.datasets.put(['foo'], 'foo')
+        # ensure dataset is in default bucket, not in prod
+        self.assertIn('foo', om.datasets.list())
+        self.assertNotIn('foo', prod.datasets.list())
+        # promote to prod
+        om.datasets.promote('foo', prod.datasets)
+        self.assertIn('foo', prod.datasets.list())
+
+    def test_model_promotion(self):
+        om = self.om
+        prod = om['prod']
+        reg = LinearRegression()
+        om.models.put(reg, 'mymodel')
+        # ensure dataset is in default bucket, not in prod
+        self.assertIn('mymodel', om.models.list())
+        self.assertNotIn('mymodel', prod.models.list())
+        # promote to prod
+        om.models.promote('mymodel', prod.models)
+        self.assertIn('mymodel', prod.models.list())

--- a/omegaml/tests/util.py
+++ b/omegaml/tests/util.py
@@ -7,11 +7,14 @@ import os
 
 
 class OmegaTestMixin(object):
-    def clean(self):
-        drop = self.om.models.drop
-        [drop(m, force=True) for m in self.om.models]
-        drop = self.om.datasets.drop
-        [drop(m, force=True) for m in self.om.datasets]
+    def clean(self, bucket=None):
+        om = self.om[bucket] if bucket is not None else self.om
+        drop = om.models.drop
+        [drop(m, force=True) for m in om.models]
+        drop = om.datasets.drop
+        [drop(m, force=True) for m in om.datasets]
+        self.assertListEqual(om.datasets.list(), [])
+        self.assertListEqual(om.models.list(), [])
 
 
 def tf_in_eager_execution():


### PR DESCRIPTION
* add the `prompte` operation on datasets and models across Omega instances
* enable the built-in bucket to work properly in the REST API and runtime

Note technically buckets are not required for multiple Omega instances. Buckets however enable logical datasets and model separation within a single database instance (e.g. per user, project etc.)
