### PR TITLE
enable project, user and global config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,4 @@ fabric.properties
 
 
 # End of https://www.gitignore.io/api/pycharm
+/cloud-config.yml

--- a/omegaml/__init__.py
+++ b/omegaml/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 
-# FIXME this is a hack to enable get_client_config
 import omegaml.defaults as _base_config
 from omegaml.util import load_class, settings
 

--- a/omegaml/omega.py
+++ b/omegaml/omega.py
@@ -111,9 +111,6 @@ class OmegaDeferredInstance(object):
         return getattr(self.omega, name)
 
     def __getitem__(self, bucket):
-        if self.base:
-            base = getattr(self.base, self.attribute)
-            return getattr(base, name)
         if not self.initialized:
             self.setup()
         return self.omega[bucket]

--- a/omegaml/runtimes/runtime.py
+++ b/omegaml/runtimes/runtime.py
@@ -58,6 +58,8 @@ class OmegaRuntime(object):
         # initialize celery as a runtimes
         taskpkgs = defaults.OMEGA_CELERY_IMPORTS
         celeryconf = celeryconf or defaults.OMEGA_CELERY_CONFIG
+        # ensure we use current value
+        celeryconf['CELERY_ALWAYS_EAGER'] = bool(defaults.OMEGA_LOCAL_RUNTIME)
         self.celeryapp = Celery('omegaml')
         self.celeryapp.config_from_object(celeryconf)
         # needed to get it to actually load the tasks (???)


### PR DESCRIPTION
* config.yml can now be in local directory, in user application configuration, global site configuration
* works for all platforms, using appdirs package
* name of config file can be specified using `OMEGAL_CONFIG_FILE` env var
* also fix bucket issue on install, fix bug that prevented celery's eager mode during runtime tests