### PR TITLE
Updates for SSL connections

### DIFF
--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -20,6 +20,10 @@ OMEGA_MONGO_URL = (os.environ.get('OMEGA_MONGO_URL') or
                    'mongodb://admin:foobar@localhost:27017/omega')
 #: the collection name in the mongodb used by omegaml storage
 OMEGA_MONGO_COLLECTION = 'omegaml'
+#: additional kwargs for mongodb SSL connections
+OMEGA_MONGO_SSL_KWARGS = {
+    'ssl': False,
+}
 #: if set forces eager execution of runtime tasks
 OMEGA_LOCAL_RUNTIME = os.environ.get('OMEGA_LOCAL_RUNTIME', False)
 #: the celery broker name or URL
@@ -45,6 +49,7 @@ OMEGA_CELERY_CONFIG = {
             'schedule': 60,
         },
     },
+    'BROKER_USE_SSL': os.environ.get('BROKER_USE_SSL') or False
 }
 #: celery task packages
 OMEGA_CELERY_IMPORTS = ['omegaml',

--- a/omegaml/mongoshim.py
+++ b/omegaml/mongoshim.py
@@ -1,0 +1,12 @@
+from pymongo import MongoClient as RealMongoClient
+
+
+def MongoClient(*args, **kwargs):
+    """
+    Shim function adding SSL kwargs on MongoClient instead of changing 
+    each and every location
+    """
+    from omegaml import settings
+    defaults = settings()
+    kwargs.update(defaults.OMEGA_MONGO_SSL_KWARGS)
+    return RealMongoClient(*args, **kwargs)

--- a/omegaml/store/base.py
+++ b/omegaml/store/base.py
@@ -178,7 +178,9 @@ class OmegaStore(object):
                              password=password,
                              connect=False,
                              authentication_source='admin',
-                             serverSelectionTimeoutMS=2500)
+                             serverSelectionTimeoutMS=2500,
+                             **self.defaults.OMEGA_MONGO_SSL_KWARGS,
+                            )
         self._db = getattr(connection, self.database_name)
         # mongoengine 0.15.0 connection setup is seriously broken -- it does
         # not remember username/password on authenticated connections

--- a/omegaml/store/fastinsert.py
+++ b/omegaml/store/fastinsert.py
@@ -1,6 +1,7 @@
 from multiprocessing import Pool
 from itertools import repeat
-from pymongo import MongoClient
+
+from omegaml.mongoshim import MongoClient 
 
 pool = None
 

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -118,7 +118,7 @@ def override_settings(**kwargs):
 
 def delete_database():
     """ test support """
-    from pymongo import MongoClient
+    from omegaml.mongoshim import MongoClient
 
     mongo_url = settings().OMEGA_MONGO_URL
     parsed_url = urlparse.urlparse(mongo_url)
@@ -432,7 +432,7 @@ class PickableCollection(object):
         }
 
     def __setstate__(self, state):
-        from pymongo import MongoClient
+        from omegaml.mongoshim import MongoClient
         url = 'mongodb://{credentials.username}:{credentials.password}@{host}:{port}/{database}'.format(**state)
         client = MongoClient(url, authSource=state['credentials'].source)
         db = client.get_database()


### PR DESCRIPTION
- "Create a shim function, called MongoClient in a new package omegaml/mongoshim.py (omegaml repo), then import that function instead of importing MongoClient directly. This achieves centralization of client configuration as well as reduces maintenance effort if we have to change it; also it removes the need to import settings everywhere we need to use MongoClient." - @miraculixx 

- Check environment variable for Rabbitmq SSL settings