### PR TITLE
extend cli

### DIFF
--- a/omegaml/client/cli/catchall.py
+++ b/omegaml/client/cli/catchall.py
@@ -1,15 +1,8 @@
-from omegaml.client.docoptparser import DocoptCommand
+from omegaml.client.docoptparser import CommandBase
 
 
-class GlobalCommand(DocoptCommand):
-    """
-    Usage: om <command> [<action>] [<args> ...] [options]
-           om (models|datasets|scripts|jobs) [<args> ...] [--raw] [options]
-           om runtime [<args> ...] [--async] [options]
-           om cloud [<args> ...] [options]
-           om [-h] [-hh] [--version] [--copyright]
-    """
-    command = "global"
+class CatchallCommandBase(CommandBase):
+    command = "catchall"
 
     def __call__(self):
         if self.args.get('--copyright'):
@@ -18,5 +11,4 @@ class GlobalCommand(DocoptCommand):
             logger.info("third party components (c) by their respective copyright holders")
             logger.info("see LICENSE and THIRDPARTY-LICENSES at https://github.com/omegaml/omegaml/")
             return
-        self.help()
-
+        self.parser.help()

--- a/omegaml/client/cli/cloud.py
+++ b/omegaml/client/cli/cloud.py
@@ -1,10 +1,10 @@
-from omegaml.client.docoptparser import DocoptCommand
+from omegaml.client.docoptparser import CommandBase
 from omegaml.client.userconf import save_userconfig_from_apikey
 from omegaml.client.util import get_omega
 from omegaml.defaults import update_from_config
 
 
-class CloudCommand(DocoptCommand):
+class CloudCommandBase(CommandBase):
     """
     Usage:
       om cloud login [<userid>] [<apikey>] [options]
@@ -23,9 +23,9 @@ class CloudCommand(DocoptCommand):
         api_url = self.args.get('--apiurl')
         configfile = self.args.get('--config') or 'config.yml'
         if not userid:
-            userid = input('Userid: ')
+            userid = self.ask('Userid:')
         if not apikey:
-            apikey = input('Apikey: ')
+            apikey = self.ask('Apikey:')
         save_userconfig_from_apikey(configfile, userid, apikey, api_url=api_url)
 
     def config(self):

--- a/omegaml/client/cli/models.py
+++ b/omegaml/client/cli/models.py
@@ -1,23 +1,28 @@
 from importlib import import_module
 
-from omegaml.client.docoptparser import DocoptCommand
+from omegaml.client.docoptparser import CommandBase
 from omegaml.client.util import get_omega
 
 
-class ModelsCommand(DocoptCommand):
+class ModelsCommandBase(CommandBase):
     """
     Usage:
       om models put <module.callable> <name>
-      om models list [<pattern>] [--raw]
+      om models list [<pattern>] [--raw] [-E|--regexp] [options]
       om models metadata <name>
+
+    Description:
+        Great stuff with models
     """
     command = 'models'
 
     def list(self):
         om = get_omega(self.args)
         pattern = self.args.get('<pattern>')
+        regexp = self.args.get('--regexp') or self.args.get('-E')
         raw = self.args.get('--raw')
-        self.logger.info(om.models.list(pattern=pattern, raw=raw))
+        kwargs = dict(regexp=pattern) if regexp else dict(pattern=pattern)
+        self.logger.info(om.models.list(raw=raw, **kwargs))
 
     def put(self):
         om = get_omega(self.args)

--- a/omegaml/client/cli/scripts.py
+++ b/omegaml/client/cli/scripts.py
@@ -1,21 +1,22 @@
 import os
 
-from omegaml.client.docoptparser import DocoptCommand
+from omegaml.client.docoptparser import CommandBase
 from omegaml.client.util import get_omega
 
 
-class ScriptsCommand(DocoptCommand):
+class ScriptsCommandBase(CommandBase):
     """
     Usage:
         om scripts list [<pattern>] [options]
         om scripts put <path> <name> [options]
+        om scripts delete <name> [options]
     """
     command = 'scripts'
 
     def list(self):
         om = get_omega(self.args)
         raw = self.args.get('--raw', False)
-        print(om.scripts.list(raw=raw))
+        self.logger.info(om.scripts.list(raw=raw))
 
     def put(self):
         om = get_omega(self.args)
@@ -25,8 +26,12 @@ class ScriptsCommand(DocoptCommand):
             name = name or os.path.basename(script_path)
             abs_path = os.path.abspath(script_path)
             meta = om.scripts.put('pkg://{}'.format(abs_path), name)
-            print(meta)
+            self.logger.info(meta)
         else:
             raise ValueError('{} is not a valid path'.format(script_path))
 
-        
+    def delete(self):
+        om = get_omega(self.args)
+        name = self.args.get('<name>')
+        om.scripts.drop(name, force=True)
+

--- a/omegaml/client/cli/shell.py
+++ b/omegaml/client/cli/shell.py
@@ -1,9 +1,9 @@
 
-from omegaml.client.docoptparser import DocoptCommand
+from omegaml.client.docoptparser import CommandBase
 from omegaml.client.util import get_omega
 
 
-class ShellCommand(DocoptCommand):
+class ShellCommandBase(CommandBase):
     """
     Usage:
         om shell [options]

--- a/omegaml/client/cloud.py
+++ b/omegaml/client/cloud.py
@@ -70,7 +70,7 @@ def setup(userid=None, apikey=None, api_url=None, qualifier=None, bucket=None):
     om.Omega = OmegaCloud
     om.setup = setup
     om.get_omega_for_task = lambda *args, **kwargs: setup(*args, **kwargs)
-    om = get_omega_from_apikey(userid, apikey, api_url=api_url, qualifier=qualifier)
+    om = get_omega_from_apikey(userid, apikey, api_url=api_url, qualifier=qualifier, view=False)
     return om[bucket]
 
 

--- a/omegaml/client/docoptparser.py
+++ b/omegaml/client/docoptparser.py
@@ -2,36 +2,45 @@
 A parser/processor to simplify modular docopt cli
 """
 import logging
+import os
 import re
 import sys
+from getpass import getpass
 from textwrap import dedent
 
-import os
 from docopt import docopt, DocoptExit, DocoptLanguageError
 
 
-class DocoptParser:
+class CommandParser:
     """
-    A simplified way to implement modular doctopt processors
+    A pythonic, declarative and modular approach to cli (based on docopt)
 
     Why?
-        To make cli implementation a breeze, perhaps even fun.
+        To make cli implementation a breeze, perhaps even fun: No more untestable
+        if/then mess. Every command is a class, every action is a method.
 
-        doctopt is a great way to specify and parse command line arguments.
-        However the developer is left to provide an interpretation and
-        implementation of the parsed arguments. The implementation quickly
-        becomes a large cascade of if/then/else: a bug feast waiting
-        to happen and a maintenance nightmare.
+    Tell me more!
+        CommandParser provides a straight-forward way to implement a modular
+        cli, using docopt as the command line parser. In a nutshell,
+        a Command is a Python class that provides a method for each action
+        to be performed, thus greatly reducing the need for if/then constructs
+        while modularising documentation and implementation of subcommands.
 
-        DocoptParser provides a straight-forward way to implement modular
-        commands for processing, using docopt as the command line parser. In
-        a nutshell, a command is a Python class that provides a method for
-        each action to be performed, thus removing the need for large if/then
-        constructs while modularising documentation and implementation of
-        subcommands.
+    Why not use docopt directly?
+        doctopt is a great way to specify and parse command line arguments
+        and CommandParser uses it as the actual parser. With docopt however
+        the developer is left to provide an interpretation and implementation
+        of the parsed arguments. The implementation quickly becomes a large
+        cascade of if/then/else: a bug feast waiting to happen and a
+        maintenance nightmare. Also hard to write unit tests. Note that's not
+        the fault of docopt, it's does what it does flawlessly. CommandParser
+        provides the missing link from docopt's parsing to implementation.
+
 
     Usage:
-        ___doc___ = ''' Usage: pgm.py foo bar [--baz]
+        # pgm.py
+        ___doc___ = '''Usage: pgm.py foo bar [--baz]
+                                     foo bax [--pox]
 
         [usage:foo]
 
@@ -40,11 +49,14 @@ class DocoptParser:
 
         [options:foo]
         '''
-        DocoptParser(__doc__, [FooCommand, ...]).parse().process()
+        CommandParser(__doc__, [FooCommand, ...]).parse().process()
+        # that's it, notice there are no if/then cascades
+        # end of pgm.py
 
         where FooCommand is
 
-            class FooCommand(DocoptCommand):
+            # foo.py
+            class FooCommand(CommandBase):
                 '''
                 Usage: pgm.py foo bar [--baz]
 
@@ -56,16 +68,29 @@ class DocoptParser:
                 options_header = 'Options for foo' # optional
 
                 def bar(self):
-                    # the bar command, doctopt output is in self.args
+                    # the bar command, docopt output is in self.args
+                    # as parsed to the docstring of foo.py. If you want
+                    # self.args of pgm.py, access self.parser.args
+                    #
                     # to write output, use self.logger, a Python logger
                     # which by default prints to stdout
+                    ... your code ...
+                    baz = self.args.get('--baz')
+                    self.logger.info(f"Hello {baz}")
 
+                def bax(self):
+                    # the bax command ...
+                    pox = self.args.get('--pox')
+                    self.logger.info(f"Welcome {pox}")
 
-        Upon the call to .process(), DocoptParser will find and call the
+                # notice the absence of if/then. every action is a method
+            # -- end of foo.py
+
+        Upon the call to .process(), CommandParser will find and call the
         FooCommmand.bar() method automatically. In bar() use self.args
-        to get the parsed arguments as returned by docopt().
+        to get the parsed arguments as returned by docopt(FooCommand.__doc__).
 
-        DocoptParser will automatically replace [usage:foo] and [options:foo]
+        CommandParser will automatically replace [usage:foo] and [options:foo]
         with the FooCommand.__doc__ string, replacing the latter's Usage:
         with the usage_header and Options: with options_header
 
@@ -82,6 +107,19 @@ class DocoptParser:
             Options for foo
                 --baz  baz description
 
+    How to implement help:
+        CommandParser automatically handles -h, --help and prog help <action>
+        -h prints only the usage section, --help and prog help will print all sections
+
+        If a command is given (e.g. prog foo -h) it will print the usage or help
+        of the command.
+
+        To override what is printed for help, implement the Command.help() method.
+
+            # FooCommand
+            def help(self, usage_only=True):
+                ...
+
     How to print output in a command:
         You should avoid using print() as it is not really a good way to
         write modular, debuggable code. If your cli is more than a few
@@ -95,10 +133,76 @@ class DocoptParser:
         set whatever format you like, then use
 
             logger = ... # your logger setup
-            DocoptParser(..., logger=logger)
+            CommandParser(..., logger=logger)
 
         To change the loglevel, add --loglevel in options, pass INFO, DEBUG
         or ERROR
+
+
+    Optional Description tag:
+        For the top level module and each command you can add more descriptions
+        that only get printed on prog help or prog help <action>
+
+        # pgm.py
+        (...)
+
+        Description:
+            lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+            lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+
+        [description:foo]
+
+        # foo.py
+        '''
+        (...)
+
+        Description:
+            lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+            lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+        '''
+
+        The help text will thus be:
+
+            Usage: pgm.py foo bar [--baz]
+
+            Working with foo
+                pgm.py foo bar [--baz]
+
+            Options:
+                -h | --help  this help text
+
+            Options for foo
+                --baz  baz description
+
+            Description for foo
+                lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+                lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+
+
+    My Command's parameters are not recognized:
+        Before a command's docopts are parsed, the top-level docopt must parse.
+        Thus if you do something like this, your command will never receive
+        a call:
+
+        # pgm.py
+        '''
+        Usage: pgm foo
+        '''
+
+        # foo.py
+        '''
+        Usage: pgm foo [--baz]
+        '''
+
+        To make it work, add [options:foo] to pgm.py, and either
+
+        (a) add an Options: section in foo.py that includes --baz,
+        (b) or include [--baz] as a global option
+
+        Note the effect of (a) and (b) is effectively the same, as every
+        command's options section is added to the global Options: if
+        there is a corresponding [foo:<command>] placeholder.
+
 
     Debugging:
         To debug the parser, set DOCOPT_DEBUG=1. This will print the parsed
@@ -107,34 +211,76 @@ class DocoptParser:
 
         If you don't see debug output despite specifying DOCOPT_DEBUG=1 the
         parser has not been able to parse the arguments and instead prints the
-        help text. This means that your arguments don't match any of the
-        specified arguments. Make sure that your top-level docstring supports
+        help text. This means that your argv don't match any of the
+        specified docopts. Make sure that your top-level docstring supports
         all arguments and options.
 
-        The command class is determined by a match to DocoptCommand.command,
-        either of and in this order:
+        The command class is determined by a match to CommandBase.command,
+        in this order:
             1. a valid literal passed in argv
             2. the value of the <command> tag
 
-        To change the <command> tag to something else, set parser.command_tag:
+        The method called on the command class is determined in this order:
+            3. a valid literal passed in argv
+            4. the value of the <action> tag
+            5. __call__()
 
-            parser = DocoptParser(..., command_tag='<dothis>')
+        For example, if you specify (1) or (2)
+
+            (1)
+            pgm.py foo bar
+
+            (2)
+            pgm.py <command> <action>
+
+        (1) argv = "pgm.py foo bar" => if there is FooCommand.command == 'foo', the
+            "foo" part is a literal match. The "bar" part is also a literal match.
+
+        (2) argv = "pgm.py foo bar" => if there is FooCommand.command == 'foo', the
+            "foo" part is a match by the <command> tag. The "bar" part is a match
+            by the "<action>" tag. It is translated to the corresponding method of
+            the same name if it exists, or reverts to FooCommand.__call()
+
+        In both (1) and (2) the "bar" part is translated to calling FooCommand.bar()
+        if it exists, else reverts to FooCommand.__call_().
+
+        The default command tag is '<command>', change by setting CommandParser.command_tag
+        to something else:
+
+            parser = CommandParser(..., command_tag='<dothis>')
+
+        The default action tag is '<action>'. Change by setting the Command.action_tag
+        to something else.
+
+            class FooCommand(BaseCommand):
+                action_tag = '<dothis>'
+                ...
+
     """
 
     def __init__(self, docs, commands, argv=None, version=None, logger=None,
-                 command_tag=None):
+                 command_tag=None, catchall='catchall', askfn=None):
         self.docs = docs
         self.commands = commands  # available command implementations
-        self.command = None  # chosen command implementation, see get_command
+        self.command = None  # chosen command implementation, see parse_command
         self.command_tag = command_tag or '<command>'
         self.argv = argv or sys.argv[1:]
         self.version = version
         self.args = None
+        self.catchall = catchall
         self._logger = logger
+        self._askfn = askfn
         self.apply_command_usage()
 
     @property
     def logger(self):
+        """
+        return the logger instance, defaults to the console logger
+
+        Returns:
+            a logger, any command instance should use this logger for output
+            this helps not only output control but also testing.
+        """
         if self._logger is None:
             self._logger = setup_console_logger()
             loglevel = self.args.get('--loglevel', 'INFO')
@@ -145,26 +291,76 @@ class DocoptParser:
     def should_debug(self):
         return os.environ.get('DOCOPT_DEBUG')
 
+    @property
+    def silent(self):
+        return self.args.get('-q') or self.args.get('--noinput')
+
     def apply_command_usage(self):
+        """
+        For every command add usage, options and descriptions to global docs
+
+        This works by extracting the usage, options and descriptions from
+        the doc string of every registered command class and adding these
+        to the global docs by replacing the corresponding [usage:<command>],
+        [options:<command>] and [descriptions:<command] sections, respectively.
+
+        Returns:
+            None
+        """
         # replace [usage:<command>] [options:<command>] placeholders with command.__doc__
         for command in self.commands:
             if command.__doc__:
-                usage, options, description = command.get_command_doc()
+                usage, options, description = command.get_command_docparts()
                 usage_placeholder = '[usage:{}]'.format(command.command)
                 options_placeholder = '[options:{}]'.format(command.command)
                 descr_placeholder = '[description:{}]'.format(command.command)
                 self.docs = self.docs.replace(usage_placeholder, usage)
                 self.docs = self.docs.replace(options_placeholder, options)
                 self.docs = re.sub(r'\n\s*\n', '\n\n', self.docs)
-            if any(v in self.argv for v in ('--help-ext', '-H', '-hh')):
-                self.docs = self.docs.replace(descr_placeholder, description)
-            else:
-                self.docs = self.docs.replace(descr_placeholder, '')
+                if any(v in self.argv for v in ('--help-ext', '-H', '-hh', 'help')):
+                    self.docs = self.docs.replace(descr_placeholder, description)
+                else:
+                    self.docs = self.docs.replace(descr_placeholder, '')
 
     def parse(self):
-        self.args = safe_docopt(self.docs, argv=self.argv, version=self.version)
-        self.command = self.get_command()
+        """
+        Parse the doc string given on instantiation, determine current command
+
+        Returns:
+            the parser self
+        """
+        try:
+            self.args = safe_docopt(self.docs, argv=self.argv, version=self.version, help=False)
+        except DocoptExit:
+            # by specifying docopt(help=False) we get to control what happens on parse failure
+            if self.argv:
+                # if help requested, show help. this simulates a valid Usage: help <action>
+                if self.argv[0] in ('help', '--help'):
+                    action = self.argv[1] if len(self.argv) > 1 else None
+                    self.args = {
+                        '<command>': 'help',
+                        '<action>': action,
+                    }
+                    self.help(usage_only=False)
+                    # raise SystemExit because
+                    raise SystemExit
+                # custom handling should be provided by a Command with command='catchall'
+                elif self.argv[0] == '--copyright':
+                    self.args = {
+                        '--copyright': True,
+                    }
+                else:
+                    # this re-raises DocoptExit which prints usage
+                    raise
+            else:
+                # this re-raises DocoptExit which prints usage
+                raise
+        # if we get here it means docopt has decided all the arguments are valid
+        # -- see if we have a command
+        self.command = self.parse_command()
+        # -- no command?!
         if not self.command:
+            self.help()
             raise DocoptExit()
         if self.should_debug:
             print("*** docopt parsed args", self.args)
@@ -172,33 +368,143 @@ class DocoptParser:
             print("*** docopt using command method {}".format(repr(self.command.get_command_method())))
         return self
 
-    def get_command(self):
-        # find the command
+    def parse_command(self):
+        """
+        Instantiate the command requested
+
+        The command requested is determined by considering
+            * a literal as specified
+            * a <command> placeholder
+            * neither literal nor <command>, the 'catchall' command, if present
+
+        Returns:
+            the command class or None
+        """
         for commandcls in self.commands:
-            global_command = False
+            is_global_command = False
             # given as literal
             command_asliteral = self.args.get(commandcls.command)
             # given as <command> arg
             command_asarg = self.args.get(self.command_tag) == commandcls.command
             # catch all?
             if not (command_asliteral or command_asarg):
-                global_command = commandcls.command == 'global'
-            if command_asliteral or command_asarg or global_command:
-                command = commandcls(self.args, argv=self.argv,
-                                     logger=self.logger, global_docs=self.docs)
+                is_global_command = commandcls.command == self.catchall
+            if command_asliteral or command_asarg or is_global_command:
+                command = self._command_instance(commandcls)
+                command.parse()
                 return command
+        self.help()
+
+    def _command_instance(self, commandcls):
+        # instantiate the commandcls given current arguments and a parsed global instance
+        command = commandcls(commandcls.__doc__, argv=self.argv,
+                             logger=self.logger, parser=self)
+        return command
 
     def process(self):
-        # resolve command and method to call
-        assert self.command is not None, "you must call DocoptParser.parse()"
+        """
+        Process the command as identified in parse
+
+        Processing means to find the <action> method to call on the command class,
+        see get_command_method() for details
+
+        Returns:
+
+        """
+        assert self.command is not None, "you must call CommandParser.parse()"
         meth = self.command.get_command_method()
         if meth:
             return meth()
 
+    def help(self, usage_only=True):
+        """
+        show default help
 
-class DocoptCommand:
+        This assumes that the docs contain any of the following Usage patterns:
+
+            Usage:
+                prog <command> <action>
+                prog help <a-command>
+
+        Either of the following is shown, in this order:
+            - if the command was 'help', but no <a-command> was given, show
+              self.docs
+            - if <a-command> was given this is used to lookup the actual command,
+              then calls command.help()
+            - if <command> was not 'help', i.e. we got here by some command
+              calling parser.help(), we show usage information by calling the
+              command's command.help(usage_only=True)
+            - if no command can be identified, we let the user know we don't
+              know what to do. If possible we hint at the closest command that
+              is similar to the requested <command> or help <a-command>
+
+        This is called after the following has already happened:
+            - docopt has decided argv was valid as given by specs
+            - no command was found, or the command did not identify a method
+            - if none of the above, the command called parser.help()
+
+        Raises:
+            ValueError(message + hint) if no command was found
+        """
+        command_requested = self.args.get(self.command_tag)
+        help_requested = command_requested == 'help' or self.args.get('help')
+        action_requested = self.args.get('<any-command>')
+        closest_command = None
+        # if help was actually requested, see if we can find a command
+        if help_requested:
+            if not action_requested:
+                docs = self.docs
+                self.logger.info(dedent(docs).strip())
+                return
+            command_requested = action_requested
+            usage_only = False
+        for commandcls in self.commands:
+            if commandcls.command == command_requested:
+                command = self._command_instance(commandcls)
+                return command.help(usage_only=usage_only)
+            if command_requested in commandcls.command or commandcls.command in command_requested:
+                closest_command = commandcls.command
+        hint = f"try: om help {closest_command}" if closest_command else 'try: om -h'
+        msg = f"sorry, I don't know about >{command_requested}<. {hint}"
+        raise SystemExit(msg)
+
+    def ask(self, prompt, hide=False, options=None, default=None):
+        """
+        ask user input
+
+        Can be overridden by providing CommandParser(..., askfn=callable), e.g.
+        for testing purpose
+
+        Args:
+            prompt (str): the prompt text
+            hide (bool): if True don't ask, just return default
+            options (str): options string, if provided answer will be checked
+                to be in options (lowercase)
+            default (str): the default answer if no answer given or self.silent
+                is active (-q switch)
+
+        Returns:
+            answer as str
+        """
+        if self._askfn:
+            return self._askfn(prompt, hide=hide, options=options, default=default,
+                               parser=self)
+        if not self.silent:
+            options_text = f'[{options}] ' if options else ''
+            prompt = f'{prompt} {options_text}'
+            if hide:
+                value = getpass(prompt=prompt)
+            value = input(prompt)
+            if not value and default:
+                return default
+            if options:
+                assert value.lower() in options.lower()
+        return default
+
+
+class CommandBase:
     """
-    Base class for DocoptParser commands
+    Base class for CommandParser commands
 
     This assumes either of the following docopt formats:
 
@@ -206,12 +512,12 @@ class DocoptCommand:
         pgm.py command action
 
     How to use:
-        1. implement a DocoptCommand subclass for the command you wish to handle
-        2. implement methods for each action
+        1. implement a CommandBase subclass for the command you wish to handle
+        2. implement methods for each action (e.g. action <dothis> gets method dothis)
         3. to process command without action, implement __call__
-        4. Pass your DocoptCommand classes as the command list to DocoptParser
+        4. Pass your CommandBase classes as the command list to CommandParser
 
-        Each DocoptCommand subclass must at least provide the command name
+        Each CommandBase subclass must at least provide the command name
         and either a valid action method or the __call__ method.
 
         Each action method, including __call__, is of format
@@ -219,14 +525,14 @@ class DocoptCommand:
                 # use self.args to get parsed arguments
 
         If a method with equal name as the action is found, it will be called.
-        If no method is found, __call__ will be invoked, which by default raises
-        NotImplementedError.
+        If no method is found, __call__ will be invoked, which by default prints
+        the command's help
 
         Note a named <argument> will be used to lookup a method based on the
         value passed. e.g if <argument> is specified as foo then the foo method
         will be found.
 
-        See DocoptParser for a complete example.
+        See CommandParser for a complete example.
 
     Documentation of commands:
         A command class can have its own docstring in the same format as the
@@ -239,37 +545,64 @@ class DocoptCommand:
         placeholders. In this case the Usage: and Options: strings will be
         replaced by usage_header and options_header, respectively.
 
-        See DocoptParser for a complete example.
+        See CommandParser for a complete example.
     """
     command = 'unspecified'
+    action_tag = '<action>'
     usage_header = 'Usage of {self.command}'
     options_header = 'Options for {self.command}'
     description_header = 'Working with {self.command}'
 
-    def __init__(self, args, argv=None, logger=None, docs=None,
-                 global_docs=None):
+    def __init__(self, docs, argv=None, logger=None, parser=None):
         # initialize, if this class contains a __doc__ header
         # with a Usage: section, self.args will automatically
         # be updated accordingly.
-        self.args = args
-        self.argv = argv
+        self.argv = argv or sys.argv[1:]
         self.logger = logger
         self.docs = docs or self.__doc__
-        self.global_docs = global_docs
-        self.parse()
+        self.parser = parser
+        self.global_docs = self.parser.docs if self.parser else None
+        self.args = {}
 
     def parse(self):
-        if (self.__doc__ and 'usage:' in self.__doc__.lower() or
-                self.__doc__ and 'options:' in self.__doc__.lower()):
-            docs = self.add_global_options()
-            args = safe_docopt(docs, argv=self.argv)
-            self.args.update(args)
+        """
+        Use docopt on self.docs and self.args
+
+        If this method returns, self.args will contain the parsed options
+        as given in self.docs
+        """
+        if self.docs is None:
+            return
+        docs = self.add_global_options() if self.global_docs else self.docs
+        args = safe_docopt(docs, argv=self.argv, help=False)
+        self.args.update(args)
+
+    @property
+    def has_usage(self):
+        return self.docs and 'usage:' in self.__doc__.lower()
+
+    @property
+    def has_description(self):
+        return self.docs and 'description:' in self.__doc__.lower()
+
+    @property
+    def usage(self):
+        lines = []
+        for line in self.docs.split('\n'):
+            if any(v in line.lower() for v in ('options:', 'description:')):
+                break
+            lines.append(line)
+        return '\n'.join(lines)
+
+    @property
+    def silent(self):
+        return self.parser.silent
 
     def add_global_options(self):
         # add Options: from top level parser. this is to make sure
         # that global options are checked on any [options] placeholder
         # in this command's docstring
-        if self.global_docs and 'Options:' in self.global_docs:
+        if self.global_docs and 'options:' in self.global_docs.lower():
             # get global options as clean as possible
             global_options = self.global_docs.split('Options:', 1)[1]
             global_options = global_options.split('\n')
@@ -294,26 +627,56 @@ class DocoptCommand:
             docs = self.docs
         return docs
 
+    def help(self, usage_only=False):
+        """
+        Display command's help
+
+        This is called by the parser upon the help command, and if __call__
+        is not implemented.
+
+        Args:
+            usage_only (bool): if True, show only usage, else show full docs
+
+        Returns:
+
+        """
+        if usage_only:
+            self.logger.info(dedent(self.usage))
+        else:
+            self.logger.info(dedent(self.docs))
+
     def __call__(self):
-        raise NotImplementedError
+        """
+        If no method was found, this is what gets help. By
+        default we call self.help(usage_only=True) to show
+        usage information
+        """
+        self.help(usage_only=True)
 
     def get_command_method(self):
-        # get the method to call, by default return command itself
-        # for <action> style arguments will use the value to lookup
-        # the method
+        """
+        get the method to call, by default return command itself
+
+        for <action> style arguments will use the value to lookup.
+        The action tag used for the lookup is self.action_tag
+
+        Returns:
+              the method or self if none was found. Returning self
+              means __call__() will be called
+        """
+        #
+        #
+        #
         for k, v in self.args.items():
-            lookup = str(v if k.startswith('<') else k)
+            lookup = str(v if k == self.action_tag else k)
             if v:
                 meth = getattr(self, lookup, None)
                 if meth is not None:
                     return meth
         return self
 
-    def help(self):
-        self.logger.info(dedent(self.__doc__).strip())
-
     @classmethod
-    def get_command_doc(self):
+    def get_command_docparts(self):
         # return usage, options, description to replace
         # [usage:<command>], [options:<command>], [description:<command>]
         # -- format headers
@@ -327,20 +690,114 @@ class DocoptCommand:
         clean_command_doc = clean_command_doc.replace('Description:', 'description:')
         # ensure all sections are present
         if 'options:' not in clean_command_doc:
-            clean_command_doc += '\noptions:\n'
+            # ensure options is before description
+            if 'description:' in clean_command_doc:
+                before, after = clean_command_doc.split('description:')
+                before += '\noptions:\n'
+                clean_command_doc = before + 'description:' + after
+            else:
+                clean_command_doc += '\noptions:\n'
         if 'description:' not in clean_command_doc:
             clean_command_doc += '\ndescription:\n'
         # split
-        usage, options = clean_command_doc.split('options:')
-        options, description = options.split('description:')
+        try:
+            usage, options = clean_command_doc.split('options:')
+            options, description = options.split('description:')
+        except:
+            raise ValueError(f"cannot parse {clean_command_doc}")
         # ensure headers are not interfering with top-level
         usage = usage.replace('usage:', usage_header)
         options = (options_header + options) if options.strip() else ''
         description = (description_header + description) if description.strip() else ''
         return usage, options, description
 
+    def parse_kwargs(self, argname, resolve_bool=True, splitby=None,
+                     pyeval=False, literal_escape=None,
+                     **defaults):
+        """
+        Parse [<kw=value>] and [<kw=value>...] kind arguments
+
+        Usage:
+            Positional parameters
+
+                prog [<kw=value>]
+                prog [<kw=value>...]
+
+            => in your BaseCommand call self.parse_kwargs('<kw=value>') to get back the parsed dict
+
+            Long (named) parameters
+
+                prog [--param=<kw=value>]
+                prog [--param=<kw=value>]...
+
+            => in your BaseCommand call self.parse_kwargs('--param') to get back the parsed dict
+
+        Examples:
+                a=1    => { a: '1' }
+                a=1    => { a: 1 } # assuming pyeval=True
+                a=yes  => { a: True }
+                a=false => { a: False }
+                a=*false => { a: 'false' }
+                a=[0,1,2] => { a: [0,1,2] } # assuming pyeval=True
+                a=1,2,3   => { a: ['1', '2', '3'] # assuming splitby=', pyeval=False
+
+        Args:
+            argname (str): the name of the argument as specified in docopt
+            splitby (str): specify string to split values by, by default splits on comma,
+                unless pyeval is given. If pyeval is True by default does not split
+            resolve_bool (bool): resolve yes/true => True, no/false => False (defaults to True)
+            pyeval (bool): eval() the final value, defaults to False, can also be a callable
+            literal_escape (str): the escape char to keep yes/true, no/false, defaults to *
+                if resolve_bool is True, else no literal escape
+            **defaults (dict): any defaults
+
+        Returns:
+            dict of kw => value, can contain a single or multiple items
+        """
+        # replace literal *yes, *no with 'yes', 'no'
+        # replace literal *true, *false with 'true', 'false'
+        # replace yes/true with True
+        # replace no/false with False
+        # split values that contain a comma to a list
+        splitby = None if pyeval else ','
+        literal_escape = '*' if not resolve_bool else None
+        values = self.args.get(argname)
+        if values is None:
+            return {}
+        if not isinstance(values, list):
+            values = [values]  # allow single values
+        # seperate method to make it reusable by parse_kwargs and parse_kwarg
+        BOOLMAP = {'true': True, 'yes': True,
+                   'no': False, 'false': False,
+                   'y': True, 'n': False}
+        doeval = lambda v: pyeval(v) if callable(pyeval) else (eval(v) if pyeval else v)
+        split = lambda v: ([v for v in v.split(splitby) if v]
+                           if splitby and (len(v) > 1 and splitby in v)
+                           else v)
+        literal = lambda v: v.replace(literal_escape, '') if literal_escape else v
+        truefalse = lambda v: BOOLMAP.get(v.lower()) if resolve_bool else v
+        resolve = lambda v: truefalse(v) if resolve_bool and v in BOOLMAP else doeval(split(literal(v)))
+        requested_kwargs = {k: resolve(v) for arg in values for k, v in [arg.split('=', 1)]}
+        real_kwargs = {}
+        real_kwargs.update(defaults)
+        real_kwargs.update(requested_kwargs)
+        return real_kwargs
+
+    def ask(self, *args, **kwargs):
+        return self.parser.ask(*args, **kwargs)
+
 
 def safe_docopt(doc, argv=None, help=True, version=None, options_first=False):
+    """
+    A docopt drop-in replacement to print meaning full error messages in case
+    of a DocoptLanguageError exception
+
+    Args:
+        same as docopt
+
+    Returns
+        parsed args
+    """
     try:
         args = docopt(doc, argv=argv, help=help, version=version, options_first=options_first)
     except DocoptLanguageError as e:
@@ -354,6 +811,12 @@ def safe_docopt(doc, argv=None, help=True, version=None, options_first=False):
 
 
 def setup_console_logger():
+    """
+    Set up a default console logger that prints messages as is
+
+    Returns:
+        the logger instance
+    """
     logger = logging.getLogger()
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter('%(message)s')

--- a/omegaml/tests/cli/scenarios.py
+++ b/omegaml/tests/cli/scenarios.py
@@ -1,0 +1,202 @@
+import os
+import string
+import sys
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+from nbformat import v4
+from scipy.misc import imsave
+from sklearn.linear_model import LinearRegression
+
+from omegaml.client import cli
+
+
+class CliTestScenarios:
+    """TestCase plugin with common environment scenarios"""
+
+    def setUp(self):
+        super().setUp()
+        self.pretend_logger = None
+
+    def get_test_logger(self):
+        """
+        create a test logger that captures info, error, debug output
+
+        Returns:
+            a logger object, use logger.data['info|error|debug'] to get
+            respective logger output by cli
+        """
+
+        class TestLogger:
+            data = defaultdict(list)
+
+            def info(self, *args):
+                self.data['info'].append(args)
+
+            def error(self, *args):
+                self.data['error'].append(args)
+
+            def debug(self, *args):
+                self.data['debug'].append(args)
+
+            def clear(self):
+                self.data = defaultdict(list)
+
+        return TestLogger()
+
+    def pretend_log(self, *args, start_empty=False, level='info'):
+        """
+        return what would be written in log
+
+        Use to generate expected test output feasible for assertLogEqual
+        This way you don't need to understand the internal of TestLogger
+
+        Args:
+            args: what would be passed to logger.info(args)
+
+        Usage:
+            you would like to test if the cli writes a log entry of some kind:
+
+            # you expect the cli to issue a log statement like this
+            logger.info('there were 0 items in the list')
+
+            # code to write
+            expected = self.pretend_log('there were 0 items in the list')
+            self.assertLogEqual('info', expected)
+
+        Returns:
+            the actual log entry that would be written
+        """
+        if self.pretend_logger is None:
+            self.pretend_logger = self.get_test_logger()
+        logger = self.pretend_logger
+        if start_empty:
+            logger.clear()
+        level_logger = getattr(logger, level)
+        level_logger(*args)
+        return logger.data[level]
+
+    def get_log(self, level):
+        return self.cli_logger.data[level]
+
+    def assertLogSize(self, level, size):
+        """ assert log of level has number of entries (lines) """
+        self.assertEqual(size, len(self.get_log(level)))
+
+    def assertLogEqual(self, level, expected):
+        """ assert log of level has expected contents """
+        self.assertEqual(expected, self.get_log(level))
+
+    def assertLogContains(self, level, expected, compare_as=str):
+        """
+        assert the log level contains some content
+
+        Each log entry is compared to expected, if no match is found
+        will raise AssertionError. By default the comparision is
+        a test of str(expected) in str(log) for every entry in expected
+        and log respectively. To compare as object, pass compare_as=object
+
+        Args:
+            level: the log level
+            expected: the expected entry(ies), as returned by pretend_log(). if
+               a string is passed will be replaced with the result of
+               pretend_log(level, expected)
+            compare_as: type or callable for casting entries, defaults to str
+
+        Raises:
+            AssertionError if no match is found
+        """
+        if isinstance(expected, str):
+            expected = self.pretend_log(expected, level=level)[-1:]
+        data = self.get_log(level)
+        if compare_as is not object:
+            # unpack log entries, not a log entry is a *args tuple
+            # hence we need to iterate that to get each value
+            expected = [compare_as(v) for args in expected for v in args]
+            data = [compare_as(v) for args in data for v in args]
+        match = False
+        for e in expected:
+            for d in data:
+                match |= e in d
+        if not match:
+            raise AssertionError(f'{expected} is not in {data} compared as {compare_as}')
+
+    def cli(self, argv, new_start=False, **kwargs):
+        self.cli_logger = self.get_test_logger()
+        if new_start:
+            self.cli_logger.clear()
+            self.pretend_logger.clear() if self.pretend_logger else None
+        if isinstance(argv, str):
+            argv = argv.split(' ')
+        self.cli_parser = cli.main(argv=argv, logger=self.cli_logger, **kwargs)
+
+    def make_model(self, name):
+        """
+        create and store a model
+
+        Args:
+            name: the model name
+
+        Returns:
+            Metadata of the model
+        """
+        om = self.om
+        # add a model, see that we get it back
+        reg = LinearRegression()
+        return om.models.put(reg, 'reg')
+
+    def make_dataset_from_dataframe(self, name, N=100):
+        """
+        create and store a pandas dataframe
+
+        Args:
+            name: the dataset name
+
+        Returns:
+            Metadata of the dataset
+        """
+        import pandas as pd
+        df = pd.DataFrame({
+            'x': range(N),
+            'y': range(N)
+        })
+        df['y'] = df['x'] * 2
+        return self.om.datasets.put(df, name, append=False)
+
+    def create_local_csv(self, path, size=(100, 2), sep=','):
+        """
+        create a local dataset
+
+        Args:
+            name:
+            size:
+
+        Returns:
+
+        """
+        data = np.random.randint(0, 100, size=size)
+        df = pd.DataFrame(data, columns=list(string.ascii_uppercase[0:size[1]]))
+        df.to_csv(path, index=None, sep=sep)
+        return df
+
+    def create_local_image_file(self, path):
+        import numpy as np
+        img = np.zeros([100, 100, 3], dtype=np.uint8)
+        img.fill(255)
+        imsave(path, img)
+        return img
+
+    def create_job(self, name):
+        cells = []
+        code = "print('hello')"
+        cells.append(v4.new_code_cell(source=code))
+        notebook = v4.new_notebook(cells=cells)
+        # put the notebook
+        return self.om.jobs.put(notebook, name)
+
+    def get_package_path(self):
+        basepath = os.path.join(os.path.dirname(sys.modules['omegaml'].__file__), 'example')
+        pkgpath = os.path.abspath(os.path.join(basepath, 'demo', 'helloworld'))
+        return pkgpath
+

--- a/omegaml/tests/cli/test_cli_datasets.py
+++ b/omegaml/tests/cli/test_cli_datasets.py
@@ -1,0 +1,124 @@
+from unittest import TestCase
+
+from numpy.testing import assert_array_equal
+from pandas.util.testing import assert_frame_equal
+
+from omegaml import Omega
+from omegaml.tests.cli.scenarios import CliTestScenarios
+from omegaml.tests.util import OmegaTestMixin
+from omegaml.util import temp_filename
+
+import pandas as pd
+
+class CliModelsTest(CliTestScenarios, OmegaTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.om = Omega()
+        self.clean()
+
+    def test_cli_datasets_help(self):
+        self.cli('help datasets')
+
+    def test_cli_datasets_list(self):
+        # start with empty datasets
+        self.cli('datasets list')
+        expected = self.pretend_log([])
+        self.assertLogEqual('info', expected)
+        # add a test dataset
+        self.make_dataset_from_dataframe('testds')
+        self.cli('datasets list', new_start=True)
+        expected = self.pretend_log(['testds'])
+        self.assertLogEqual('info', expected)
+        # add another one, use pattern matching
+        self.make_dataset_from_dataframe('foobar')
+        # -- just on one
+        self.cli('datasets list test*', new_start=True)
+        expected = self.pretend_log(['testds'])
+        self.assertLogEqual('info', expected)
+        # -- on the other
+        self.cli('datasets list foo*', new_start=True)
+        expected = self.pretend_log(['foobar'])
+        self.assertLogEqual('info', expected)
+        # match both
+        self.cli('datasets list foo.*|test.* -E', new_start=True)
+        expected = self.pretend_log(['foobar', 'testds'])
+        self.assertLogEqual('info', expected)
+
+    def test_cli_datasets_put(self):
+        # write a csv, read back
+        fn = temp_filename(ext='csv')
+        df = self.create_local_csv(fn)
+        self.cli(f'datasets put {fn} foobar')
+        self.assertLogContains('info', 'Metadata(')
+        self.assertLogContains('info', 'kind=pandas.dfrows')
+        dfx = self.om.datasets.get('foobar')
+        assert_frame_equal(df, dfx)
+        # write a csv, read back, use custom sep
+        fn = temp_filename(ext='csv')
+        df = self.create_local_csv(fn, sep=';')
+        self.cli(f'datasets put {fn} foxbaz --csv sep=;')
+        self.assertLogContains('info', 'Metadata(')
+        self.assertLogContains('info', 'kind=pandas.dfrows')
+        dfx = self.om.datasets.get('foxbaz')
+        assert_frame_equal(df, dfx)
+        # write some other file
+        fn = temp_filename(ext='binary')
+        df = self.create_local_csv(fn)
+        self.cli(f'datasets put {fn} binary', new_start=True)
+        print(self.get_log('info'))
+        self.assertLogContains('info', 'Metadata(')
+        self.assertLogContains('info', 'kind=python.file')
+        with open(fn, 'rb') as fin:
+            expected = fin.read()
+        data = self.om.datasets.get('binary').read()
+        self.assertEqual(expected, data)
+        # write image file
+        fn = temp_filename(ext='jpg')
+        img = self.create_local_image_file(fn)
+        self.cli(f'datasets put {fn} image', new_start=True)
+        self.assertLogContains('info', 'Metadata(')
+        self.assertLogContains('info', 'kind=ndarray.bin')
+        data = self.om.datasets.get('image')
+        assert_array_equal(data, img)
+
+    def test_cli_datasets_get(self):
+        # write a csv, read back
+        fn = temp_filename(ext='csv')
+        self.make_dataset_from_dataframe('test')
+        self.cli(f'datasets get test {fn}')
+        df = pd.read_csv(fn)
+        expected = self.om.datasets.get('test')
+        assert_frame_equal(df, expected)
+        # write a csv, read back with options
+        fn = temp_filename(ext='csv')
+        self.make_dataset_from_dataframe('test-sep')
+        self.cli(f'datasets get test-sep {fn} --csv sep=; --csv columns=x,')
+        df = pd.read_csv(fn, sep=';')
+        expected = self.om.datasets.get('test')[['x']]
+        assert_frame_equal(expected, df)
+
+    def test_cli_datasets_drop(self):
+        self.make_dataset_from_dataframe('test')
+        self.assertIn('test', self.om.datasets.list())
+        self.cli('datasets drop test')
+        self.assertNotIn('test', self.om.datasets.list())
+
+    def test_cli_datasets_metadata(self):
+        self.make_dataset_from_dataframe('test')
+        self.cli('datasets metadata test')
+        expected = self.pretend_log('"kind": "pandas.dfrows"')
+        self.assertLogContains('info', expected)
+        expected = self.pretend_log('"name": "test"')
+        self.assertLogContains('info', expected)
+
+
+
+
+
+
+
+
+
+
+
+

--- a/omegaml/tests/cli/test_cli_jobs.py
+++ b/omegaml/tests/cli/test_cli_jobs.py
@@ -1,0 +1,90 @@
+from unittest import TestCase
+
+import os
+
+import nbformat
+
+from omegaml import Omega
+from omegaml.tests.cli.scenarios import CliTestScenarios
+from omegaml.tests.util import OmegaTestMixin
+from omegaml.util import temp_filename
+
+
+class CliJobsTest(CliTestScenarios, OmegaTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.om = Omega()
+        self.clean()
+
+    def test_cli_jobs_list(self):
+        self.cli('jobs list')
+        self.assertLogContains('info', '[]')
+        self.create_job('test')
+        self.cli('jobs list')
+        self.assertLogContains('info', 'test.ipynb')
+
+    def test_cli_jobs_get(self):
+        self.create_job('test')
+        fn = temp_filename(ext='ipynb')
+        self.cli(f'jobs get test {fn}')
+        self.assertTrue(os.path.exists(fn))
+        with open(fn, 'r') as fin:
+            nb = nbformat.read(fin, as_version=4)
+        self.assertIn('cells', nb)
+        self.assertIn('hello', nb['cells'][0]['source'])
+
+    def test_cli_jobs_put(self):
+        self.assertNotIn('test', self.om.jobs.list())
+        cells = []
+        code = "print 'hello'"
+        cells.append(nbformat.v4.new_code_cell(source=code))
+        notebook = nbformat.v4.new_notebook(cells=cells)
+        fn = temp_filename(ext='ipynb')
+        with open(fn, 'w') as fout:
+            nbformat.write(notebook, fout, version=4)
+        self.cli(f'jobs put {fn} test')
+        self.assertLogContains('info', 'Metadata')
+        self.assertLogContains('info', 'name=test')
+        self.assertIn('test.ipynb', self.om.jobs.list())
+
+    def test_cli_jobs_metadata(self):
+        self.create_job('test')
+        self.cli('jobs metadata test')
+        expected = self.pretend_log('"kind": "script.ipynb"')
+        self.assertLogContains('info', expected)
+        expected = self.pretend_log('"name": "test.ipynb"')
+        self.assertLogContains('info', expected)
+
+    def test_cli_jobs_schedule(self):
+        self.create_job('test')
+        # test there is an input prompt
+        self.cli('jobs schedule test now', askfn=lambda *a, **kw: 'y')
+        self.assertLogContains('info', 'test will be scheduled to run Every minute')
+        # test there is no input prompt
+        self.cli('jobs schedule test now -q', new_start=True)
+        self.assertLogContains('info', 'Currently test is scheduled at Every minute')
+        self.assertLogContains('info', 'test is scheduled to run next at')
+        # test scheduled can be shown
+        self.cli('jobs schedule test show', new_start=True)
+        self.assertLogContains('info', 'test is scheduled to run next at')
+        # test we can delete the job schedule
+        # test there is an input prompt
+        self.cli('jobs schedule test delete', askfn=lambda *a, **kw: 'y', new_start=True)
+        self.cli('jobs schedule test show', new_start=True)
+        self.assertLogContains('info', 'Currently test is not scheduled')
+        # test we can see executed jobs
+        self.cli('jobs schedule test now', askfn=lambda *a, **kw: 'y')
+        meta = self.om.jobs.metadata('test')
+        triggers = meta.attributes['triggers']
+        trigger = triggers[-1]
+        kwargs = dict(now=trigger['run-at'], **self.om.runtime._common_kwargs)
+        self.om.runtime.task('omegaml.notebook.tasks.execute_scripts').apply_async(kwargs=kwargs).get()
+        self.cli('jobs status test', new_start=True)
+        entries =  self.get_log('info')
+        # entries example - a list of args tuples passed to logger.info(*args)
+        #   [('Runs:',), ('  2019-11-15 18:32:28.625000 OK ',),
+        #   ('Next scheduled runs:',), ('   PENDING scheduled 2019-11-15T18:34:00',)]
+        self.assertIn('Runs:', entries[0][0])
+        self.assertIn('OK', entries[1][0])
+        self.assertIn('Next scheduled runs:', entries[2][0])
+        self.assertIn('PENDING', entries[3][0])

--- a/omegaml/tests/cli/test_cli_models.py
+++ b/omegaml/tests/cli/test_cli_models.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+from omegaml import Omega
+from omegaml.tests.cli.scenarios import CliTestScenarios
+from omegaml.tests.util import OmegaTestMixin
+
+
+class CliModelsTest(CliTestScenarios, OmegaTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.om = Omega()
+        self.clean()
+
+    def test_cli_models_list(self):
+        # start with an empty list
+        self.cli('models list')
+        expected = self.pretend_log([])
+        self.assertLogSize('info', 1)
+        self.assertLogEqual('info', expected)
+        # create a model
+        self.make_model('reg')
+        self.cli('models list')
+        expected = self.pretend_log(['reg'], start_empty=True)
+        self.assertLogSize('info', 1)
+        self.assertLogEqual('info', expected)
+        # check we can get back a Metadata object
+        self.cli('models list --raw')
+        expected = self.pretend_log('Metadata(')
+        self.assertLogContains('info', expected)
+
+    def test_cli_models_put(self):
+        self.cli(f'models put omegaml.example.demo.modelfn.create_model testmodel')
+        expected = self.pretend_log('Metadata(name=testmodel')
+        self.assertLogContains('info', expected)
+
+    def test_cli_models_metadata(self):
+        self.make_model('reg')
+        self.cli('models metadata reg')
+        expected = self.pretend_log('"kind": "sklearn.joblib"')
+        self.assertLogContains('info', expected)
+        expected = self.pretend_log('"name": "reg"')
+        self.assertLogContains('info', expected)
+
+
+

--- a/omegaml/tests/cli/test_cli_runtime.py
+++ b/omegaml/tests/cli/test_cli_runtime.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from unittest import TestCase
+
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV
+
+from omegaml import Omega
+from omegaml.tests.cli.scenarios import CliTestScenarios
+from omegaml.tests.util import OmegaTestMixin
+
+
+class CliRuntimeTests(CliTestScenarios, OmegaTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.om = Omega()
+        self.clean()
+
+    def test_cli_runtime_model_fit_predict(self):
+        self.make_model('reg')
+        reg = self.om.models.get('reg')
+        self.make_dataset_from_dataframe('test', N=10)
+        # -- fit the model
+        self.cli('runtime model reg fit test[x] test[y]')
+        self.assertLogContains('info', 'Metadata')
+        # -- run a prediction, we get back actual data
+        self.cli('runtime model reg predict test[x]', new_start=True)
+        self.assertLogContains('info', '[[')
+        self.assertIsInstance(self.get_log('info')[0][0], np.ndarray)
+        # -- run a prediction, we store the results
+        self.cli('runtime model reg predict test[x] --result predictions')
+        #    expect metadata since we ask to write data to predictions
+        self.assertLogContains('info', 'Metadata')
+        df_expect = self.om.datasets.get('test')['y']
+        #    check the data has actually been stored as requested
+        df_pred = self.om.datasets.get('predictions')
+        self.assertIsNotNone(df_pred)
+        self.assertEqual(len(df_expect), len(df_pred))
+
+    def test_cli_runtime_model_gridsearch(self):
+        X, y = make_classification()
+        logreg = LogisticRegression(solver='liblinear')
+        self.om.models.put(logreg, 'logreg')
+        # perform gridsearch on runtime
+        self.om.datasets.put(X, 'testX')
+        self.om.datasets.put(y, 'testY')
+        self.cli('runtime model logreg gridsearch testX testY --param C=[.1,.5,1.0]')
+        model_meta = self.om.models.metadata('logreg')
+        self.assertIn('gridsearch', model_meta.attributes)
+        gsmodel_name = model_meta.attributes['gridsearch'][0]['gsModel']
+        gsmodel = self.om.models.get(gsmodel_name)
+        self.assertIsInstance(gsmodel, GridSearchCV)
+
+    def test_cli_runtime_script_run(self):
+        pkgpath = self.get_package_path()
+        self.cli(f'scripts put {pkgpath} helloworld')
+        self.assertLogContains('info', 'Metadata')
+        # run without kwargs
+        self.cli('runtime script helloworld run', new_start=True)
+        self.assertLogContains('info', 'hello from helloworld')
+        # with kwargs
+        self.cli('runtime script helloworld run foo=bar', new_start=True)
+        self.assertLogContains('info', '"foo": "bar"')
+
+

--- a/omegaml/tests/cli/test_cli_scripts.py
+++ b/omegaml/tests/cli/test_cli_scripts.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+
+import os
+
+import nbformat
+
+from omegaml import Omega
+from omegaml.tests.cli.scenarios import CliTestScenarios
+from omegaml.tests.util import OmegaTestMixin
+from omegaml.util import temp_filename
+
+
+class CliScriptsTest(CliTestScenarios, OmegaTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.om = Omega()
+        self.clean()
+
+    def test_cli_scripts_list_put(self):
+        self.cli(f'scripts list')
+        self.assertLogContains('info', '[]')
+        pkgpath = self.get_package_path()
+        self.cli(f'scripts put {pkgpath} helloworld', new_start=True)
+        self.assertLogContains('info', 'Metadata')
+        self.assertLogContains('info', 'name=helloworld')
+        self.cli(f'scripts list')
+        self.assertLogSize('info', 1)
+        self.assertLogContains('info', 'helloworld')
+
+    def test_cli_scripts_drop(self):
+        pkgpath = self.get_package_path()
+        self.cli(f'scripts put {pkgpath} helloworld', new_start=True)
+        self.assertIn('helloworld', self.om.scripts.list())
+        self.cli(f'scripts delete helloworld', new_start=True)
+        self.assertNotIn('helloworld', self.om.scripts.list())
+

--- a/omegaml/tests/features/cli.feature
+++ b/omegaml/tests/features/cli.feature
@@ -1,0 +1,4 @@
+Feature: omegaml cli
+
+    Scenario: foo
+        When

--- a/omegaml/tests/util.py
+++ b/omegaml/tests/util.py
@@ -13,6 +13,10 @@ class OmegaTestMixin(object):
         [drop(m, force=True) for m in om.models]
         drop = om.datasets.drop
         [drop(m, force=True) for m in om.datasets]
+        drop = om.jobs.drop
+        [drop(m, force=True) for m in om.jobs.store]
+        drop = om.scripts.drop
+        [drop(m, force=True) for m in om.scripts]
         self.assertListEqual(om.datasets.list(), [])
         self.assertListEqual(om.models.list(), [])
 

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -458,7 +458,7 @@ def extend_instance(obj, cls, *args, **kwargs):
 def temp_filename(dir=None, ext='tmp'):
     """ generate a temporary file name """
     dir = dir or tempfile.mkdtemp()
-    return os.path.join(dir, uuid.uuid4().hex)
+    return os.path.join(dir, uuid.uuid4().hex + f'.{ext}')
 
 
 def remove_temp_filename(fn, dir=True):


### PR DESCRIPTION
this improves and stabilizes the cli significantly, includes extensive test coverage

```
$ om -h
Usage: om <command> [<action>] [<args> ...] [options]
       om (models|datasets|scripts|jobs) [<args> ...] [--raw] [--replace] [options]
       om runtime [<args> ...] [--async] [options]
       om cloud [<args> ...] [options]
       om shell [options]
       om [-h] [-hh] [--version] [--copyright]

omega|ml command line client

Usage of datasets
  om datasets list [<pattern>] [--raw]
  om datasets put <path> <name> [--replace]
  om datasets get <name> <path>
  om datasets drop <name> [--force]
  om datasets metadata <name>

Usage of models
  om models put <module.callable> <name>
  om models list [<pattern>] [--raw]
  om models metadata <name>

Usage of runtime
  om runtime model <name> <model-action> [<X>] [<Y>] [<kw=value> ...>] [--async] [options]
  om runtime script <name> [<script-action>] [<args ...>] [--async] [options]
  om runtime job <name> [<job-action>] [<args ...>] [--async] [options]
  om runtime result <taskid> [options]
  om runtime ping [options]

Usage of scripts
    om scripts list [<pattern>] [options]
    om scripts put <path> <name> [options]

Usage of jobs
  om jobs list [<pattern>] [--raw] [options]
  om jobs put <path> <name> [options]
  om jobs get <name> <path> [options]
  om jobs metadata <name> [options]
  om jobs schedule <name> [show|delete|<interval>] [options]
  om jobs status <name>

Usage of cloud
  om cloud login [<userid>] [<apikey>] [options]
  om cloud config [options]

Usage of shell
    om shell [options]

Options:
  -h --help          Show this screen
  -hh --help-ext     Show detailed descriptions
  --version          Show version.
  --loglevel=LEVEL   INFO,ERROR,DEBUG [default: INFO]
  --copyright        Show copyright
  --config=CONFIG    configuration file
  --bucket=BUCKET    the bucket to use
  --local-runtime    use local runtime

Options for datasets and models
  --raw  list Metadata objects instead of names only

Options for runtime
  --async  don't wait for results, will print taskid

Options for cloud
  --userid=USERID  the userid at hub.omegaml.io (see account profile)
  --apikey=APIKEY  the apikey at hub.omegaml.io (see account profile)
  --apiurl=URL     the cloud URL [default: https://hub.omegaml.io]

Options for jobs
  --cron <spec>       the cron spec, use https://crontab.guru/
  --weekday <wday>    a day number 0-6 (0=Sunday)
  --monthday <mday>   a day of the month 1-31
  --month <month>     a month number 1-12
  --at <hh:mm>        the time (same as --hour hh --minute mm)
  --hour <hour>       the hour 0-23
  --minute <minute>   the minute 0-59
  --next <n>          show next n triggers according to interval
```