### PR TITLE
resolve deprecated scipy dependency

### DIFF
--- a/omegaml/tests/cli/scenarios.py
+++ b/omegaml/tests/cli/scenarios.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+from matplotlib.pyplot import imsave
 from nbformat import v4
-from scipy.misc import imsave
 from sklearn.linear_model import LinearRegression
 
 from omegaml.client import cli


### PR DESCRIPTION
scipy >0.1.2 removed deprecated `imsave` causing a test regression on fresh pip install