### PR TITLE
enabling automated model versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.whl
 node_modules/
 .idea
 celerybeat*

--- a/omegaml/backends/basemodel.py
+++ b/omegaml/backends/basemodel.py
@@ -1,12 +1,17 @@
+import os
+
+from mongoengine import GridFSProxy
 
 
 class BaseModelBackend(object):
-
     """
     OmegaML BaseModelBackend to be subclassed by other arbitrary backends
 
     This provides the abstract interface for any model backend to be implemented
     """
+    _backend_version_tag = '_om_backend_version'
+    _backend_version = '1'
+
     def __init__(self, model_store=None, data_store=None, **kwargs):
         assert model_store, "Need a model store"
         assert data_store, "Need a data store"
@@ -41,27 +46,81 @@ class BaseModelBackend(object):
         # support new backend architecture while keeping back compatibility
         return self.put_model(obj, name, **kwargs)
 
-    def put_model(self, obj, name, attributes=None, **kwargs):
-        """
-        store a model
+    def _tmp_packagefn(self, name):
+        filename = os.path.join(self.model_store.tmppath, name)
+        dirname = os.path.dirname(filename)
+        os.makedirs(dirname, exist_ok=True)
+        return filename
 
-        :param obj: the model object to be stored
-        :param name: the name of the object
-        :param attributes: attributes for meta data
+    def _store_file(self, infile, filename):
+        gridfile = GridFSProxy(db_alias='omega',
+                               collection_name=self.model_store._fs_collection)
+        with open(infile, 'rb') as pkgf:
+            gridfile.put(pkgf, filename=filename)
+        return gridfile
+
+    def _package_model(self, model, key, tmpfn, **kwargs):
+        """
+        implement this method to serialize a model to the given tmpfn
+
+        Args:
+            model:
+            key:
+            tmpfn:
+            **kwargs:
+
+        Returns:
+            tmpfn or absolute path of serialized file
+        """
+        raise NotImplementedError
+
+    def _extract_model(self, infile, key, tmpfn, **kwargs):
+        """
+        implement this method to deserialize a model from the given infile
+
+        Args:
+            infile: this is a file-like object supporting read() and seek(). if
+                deserializing from this does not work directly, use tmpfn
+            key:
+            tmpfn:
+            **kwargs:
+
+        Returns:
+            model instance
         """
         raise NotImplementedError
 
     def get_model(self, name, version=-1, **kwargs):
         """
-        retrieve a model
-
-        :param name: the name of the object
-        :param version: the version of the object (not supported)
+        Retrieves a pre-stored model
         """
-        raise NotImplementedError
+        meta = self.model_store.metadata(name)
+        storekey = self.model_store.object_store_key(name, 'omm', hashed=True)
+        model = self._extract_model(meta.gridfile, storekey, self._tmp_packagefn(storekey), **kwargs)
+        return model
+
+    def put_model(self, obj, name, attributes=None, _kind_version=None, **kwargs):
+        """
+        Packages a model using joblib and stores in GridFS
+        """
+        storekey = self.model_store.object_store_key(name, 'omm', hashed=True)
+        tmpfn = self._tmp_packagefn(storekey)
+        packagefname = self._package_model(obj, storekey, tmpfn, **kwargs) or tmpfn
+        gridfile = self._store_file(packagefname, storekey)
+        kind_meta = {
+            self._backend_version_tag: self._backend_version,
+        }
+        return self.model_store._make_metadata(
+            name=name,
+            prefix=self.model_store.prefix,
+            bucket=self.model_store.bucket,
+            kind=self.KIND,
+            kind_meta=kind_meta,
+            attributes=attributes,
+            gridfile=gridfile).save()
 
     def predict(
-            self, modelname, Xname, rName=None, pure_python=True, **kwargs):
+          self, modelname, Xname, rName=None, pure_python=True, **kwargs):
         """
         predict using data stored in Xname
 
@@ -71,12 +130,12 @@ class BaseModelBackend(object):
         :param pure_python: if True return a python object. If False return
             a dataframe. Defaults to True to support any client.
         :param kwargs: kwargs passed to the model's predict method
-        :return: return the predicted outcome   
+        :return: return the predicted outcome
         """
         raise NotImplementedError
 
     def predict_proba(
-            self, modelname, Xname, rName=None, pure_python=True, **kwargs):
+          self, modelname, Xname, rName=None, pure_python=True, **kwargs):
         """
         predict the probability using data stored in Xname
 
@@ -86,13 +145,13 @@ class BaseModelBackend(object):
         :param pure_python: if True return a python object. If False return
             a dataframe. Defaults to True to support any client.
         :param kwargs: kwargs passed to the model's predict method
-        :return: return the predicted outcome   
+        :return: return the predicted outcome
         """
         raise NotImplementedError
 
     def fit(self, modelname, Xname, Yname=None, pure_python=True, **kwargs):
         """
-        fit the model with data 
+        fit the model with data
 
         :param modelname: the name of the model object
         :param Xname: the name of the X data set
@@ -100,14 +159,14 @@ class BaseModelBackend(object):
         :param pure_python: if True return a python object. If False return
            a dataframe. Defaults to True to support any client.
         :param kwargs: kwargs passed to the model's predict method
-        :return: return the meta data object of the model   
+        :return: return the meta data object of the model
         """
         raise NotImplementedError
 
     def partial_fit(
-            self, modelname, Xname, Yname=None, pure_python=True, **kwargs):
+          self, modelname, Xname, Yname=None, pure_python=True, **kwargs):
         """
-        partially fit the model with data (online) 
+        partially fit the model with data (online)
 
         :param modelname: the name of the model object
         :param Xname: the name of the X data set
@@ -115,14 +174,14 @@ class BaseModelBackend(object):
         :param pure_python: if True return a python object. If False return
            a dataframe. Defaults to True to support any client.
         :param kwargs: kwargs passed to the model's predict method
-        :return: return the meta data object of the model   
+        :return: return the meta data object of the model
         """
 
         raise NotImplementedError
 
     def fit_transform(
-            self, modelname, Xname, Yname=None, rName=None, pure_python=True,
-            **kwargs):
+          self, modelname, Xname, Yname=None, rName=None, pure_python=True,
+          **kwargs):
         """
         fit and transform using data
 
@@ -133,7 +192,7 @@ class BaseModelBackend(object):
         :param pure_python: if True return a python object. If False return
            a dataframe. Defaults to True to support any client.
         :param kwargs: kwargs passed to the model's transform method
-        :return: return the meta data object of the model   
+        :return: return the meta data object of the model
         """
         raise NotImplementedError
 
@@ -145,13 +204,13 @@ class BaseModelBackend(object):
         :param Xname: the name of the X data set
         :param rName: the name of the transforms's result data object or None
         :param kwargs: kwargs passed to the model's transform method
-        :return: return the transform data of the model   
+        :return: return the transform data of the model
         """
         raise NotImplementedError
 
     def score(
-            self, modelname, Xname, Yname, rName=True, pure_python=True,
-            **kwargs):
+          self, modelname, Xname, Yname=None, rName=True, pure_python=True,
+          **kwargs):
         """
         score using data
 
@@ -162,6 +221,6 @@ class BaseModelBackend(object):
         :param pure_python: if True return a python object. If False return
            a dataframe. Defaults to True to support any client.
         :param kwargs: kwargs passed to the model's predict method
-        :return: return the score result   
+        :return: return the score result
         """
         raise NotImplementedError

--- a/omegaml/backends/package/__init__.py
+++ b/omegaml/backends/package/__init__.py
@@ -57,7 +57,8 @@ class PythonPackageData(BaseDataBackend):
         :return: the loaded module
         """
         packagefname = '{}.tar.gz'.format(os.path.join(self.data_store.tmppath, name))
-        dstdir = self.packages_path
+        self.path = self.packages_path
+        dstdir = self.path
         if not os.path.exists(os.path.join(dstdir, name)):
             filename = self.data_store._get_obj_store_key(name, '.pkg')
             outf = self.data_store.fs.get_version(filename)

--- a/omegaml/backends/scikitlearn.py
+++ b/omegaml/backends/scikitlearn.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
 import glob
+import os
+import tempfile
 from zipfile import ZipFile, ZIP_DEFLATED
 
 import datetime
-import os
-import tempfile
+import joblib
 from mongoengine.fields import GridFSProxy
 from shutil import rmtree
 from sklearn.base import BaseEstimator
@@ -15,17 +16,19 @@ from omegaml.backends.basemodel import BaseModelBackend
 from omegaml.documents import MDREGISTRY
 from omegaml.util import reshaped, gsreshaped
 
+# byte string
+_u8 = lambda t: t.encode('UTF-8', 'replace') if isinstance(t, str) else t
 
-class ScikitLearnBackend(BaseModelBackend):
-    """
-    OmegaML backend to use with ScikitLearn
-    """
+
+class ScikitLearnBackendV1(BaseModelBackend):
+    KIND = MDREGISTRY.SKLEARN_JOBLIB
 
     @classmethod
     def supports(self, obj, name, **kwargs):
         return isinstance(obj, BaseEstimator)
 
-    def _package_model(self, model, filename):
+    # kept to support legacy scikit learn model serializations prior to ~scikit learn v0.18
+    def _v1_package_model(self, model, filename):
         """
         Dumps a model using joblib and packages all of joblib files into a zip
         file
@@ -42,7 +45,7 @@ class ScikitLearnBackend(BaseModelBackend):
         rmtree(lpath)
         return zipfname
 
-    def _extract_model(self, packagefname):
+    def _v1_extract_model(self, packagefname):
         """
         Loads a model using joblib from a zip file created with _package_model
         """
@@ -56,7 +59,7 @@ class ScikitLearnBackend(BaseModelBackend):
         rmtree(lpath)
         return model
 
-    def get_model(self, name, version=-1):
+    def _v1_get_model(self, name, version=-1):
         """
         Retrieves a pre-stored model
         """
@@ -71,14 +74,14 @@ class ScikitLearnBackend(BaseModelBackend):
         outf = self.model_store.fs.get_version(filename, version=version)
         with open(packagefname, 'wb') as zipf:
             zipf.write(outf.read())
-        model = self._extract_model(packagefname)
+        model = self._v1_extract_model(packagefname)
         return model
 
-    def put_model(self, obj, name, attributes=None):
+    def _v1_put_model(self, obj, name, attributes=None):
         """
         Packages a model using joblib and stores in GridFS
         """
-        zipfname = self._package_model(obj, name)
+        zipfname = self._v1_package_model(obj, name)
         with open(zipfname, 'rb') as fzip:
             fileid = self.model_store.fs.put(
                 fzip, filename=self.model_store._get_obj_store_key(name, 'omm'))
@@ -92,6 +95,42 @@ class ScikitLearnBackend(BaseModelBackend):
             kind=MDREGISTRY.SKLEARN_JOBLIB,
             attributes=attributes,
             gridfile=gridfile).save()
+
+
+class ScikitLearnBackendV2(ScikitLearnBackendV1):
+    """
+    OmegaML backend to use with ScikitLearn
+    """
+    def _package_model(self, model, key, tmpfn):
+        """
+        Dumps a model using joblib and packages all of joblib files into a zip
+        file
+        """
+        joblib.dump(model, tmpfn, protocol=4, compress=True)
+        return tmpfn
+
+    def _extract_model(self, infile, key, tmpfn):
+        """
+        Loads a model using joblib from a zip file created with _package_model
+        """
+        with open(tmpfn, 'wb') as pkgf:
+            pkgf.write(infile.read())
+        model = joblib.load(tmpfn)
+        return model
+
+    def get_model(self, name, version=-1):
+        """
+        Retrieves a pre-stored model
+        """
+        meta = self.model_store.metadata(name)
+        if self._backend_version != meta.kind_meta.get(self._backend_version_tag):
+            return super()._v1_get_model(name, version=version)
+        return super().get_model(name, version=version)
+
+    def put_model(self, obj, name, attributes=None, _kind_version=None):
+        if _kind_version and _kind_version != self._backend_version:
+            return super()._v1_put_model(obj, name, attributes=attributes)
+        return super().put_model(obj, name, attributes=attributes)
 
     def predict(
           self, modelname, Xname, rName=None, pure_python=True, **kwargs):
@@ -161,7 +200,7 @@ class ScikitLearnBackend(BaseModelBackend):
         return meta
 
     def score(
-          self, modelname, Xname, Yname, rName=None, pure_python=True,
+          self, modelname, Xname, Yname=None, rName=None, pure_python=True,
           **kwargs):
         model = self.model_store.get(modelname)
         X = self.data_store.get(Xname)
@@ -249,3 +288,7 @@ class ScikitLearnBackend(BaseModelBackend):
         })
         meta.save()
         return meta
+
+
+class ScikitLearnBackend(ScikitLearnBackendV2):
+    pass

--- a/omegaml/backends/tensorflow/tfkeras.py
+++ b/omegaml/backends/tensorflow/tfkeras.py
@@ -34,16 +34,12 @@ class TensorflowKerasBackend(KerasBackend):
             except NotImplementedError:
                 pass
 
-    def _load_model(self, fn):
+    def _extract_model(self, infile, key, tmpfn):
         # override to implement model loading
         from tensorflow import keras
-        load_model = keras.engine.saving.load_model
-        return load_model(fn)
-
-    def _load_model(self, fn):
-        # override to implement model loading
-        from tensorflow import keras
-        return keras.models.load_model(fn)
+        with open(tmpfn, 'wb') as pkgfn:
+            pkgfn.write(infile.read())
+        return keras.models.load_model(tmpfn)
 
     def fit(self, modelname, Xname, Yname=None, pure_python=True, tpu_specs=None, **kwargs):
         meta = self.model_store.metadata(modelname)
@@ -85,5 +81,5 @@ class TensorflowKerasBackend(KerasBackend):
         fn = temp_filename()
         tpu_model.save_weights(fn, overwrite=True)
         model.load_weights(fn)
-        meta = self.put_model(model, modelname)
+        meta = self.put(model, modelname)
         return meta

--- a/omegaml/client/cli/runtime.py
+++ b/omegaml/client/cli/runtime.py
@@ -59,7 +59,7 @@ class RuntimeCommandBase(CommandBase):
             kv_dct[k] = eval(v)
         kwargs = {}
         if action in ('predict', 'predict_proba',
-                      'decision_function', 'transform', 'score'):
+                      'decision_function', 'transform'):
             # actions that take rName, but no Y
             kwargs['rName'] = output
         else:

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
-from os.path import basename
-
 import logging
 import os
-import six
 import sys
+from os.path import basename
+
+import six
 import yaml
 
 from omegaml.util import tensorflow_available, keras_available, module_available
@@ -101,6 +101,7 @@ OMEGA_STORE_MIXINS = [
     'omegaml.mixins.store.package.PythonPackageMixin',
     'omegaml.mixins.store.promotion.PromotionMixin',
     'omegaml.mixins.mdf.iotools.IOToolsStoreMixin',
+    'omegaml.mixins.store.modelversion.ModelVersionMixin',
 ]
 #: runtimes mixins
 OMEGA_RUNTIME_MIXINS = [

--- a/omegaml/mixins/store/modelversion.py
+++ b/omegaml/mixins/store/modelversion.py
@@ -1,0 +1,162 @@
+from collections import defaultdict
+from copy import deepcopy
+from hashlib import sha1
+
+# byte string
+_u8 = lambda t: t.encode('UTF-8', 'replace') if isinstance(t, str) else t
+
+
+class ModelVersionMixin(object):
+    """
+    Versioning support for models
+
+    Usage:
+        # create a new version
+        om.models.put(model, 'mymodel')
+
+        # get the most recent version
+        om.models.get('mymodel', version=-1)
+
+        # tag a model, get specific tag
+        om.models.put(model, 'mymodel', tag='foo')
+        om.models.get('mymodel', tag='foo')
+
+        # get a specific tag included in name
+        om.models.get('mymodel@foo')
+
+        # specify the commit id yourself (e.g. when integrating with git)
+        # note this does not interact with git in any way
+        om.models.put(model, 'mymodel', commit=<git ref>'
+
+    Notes:
+        * every put will create a new version
+        * it is not possible to delete a version
+        * the versioning is purely based on model Metadata,
+          all functionality will continue to work as before
+    """
+
+    def put(self, obj, name, tag=None, commit=None, previous='latest', **kwargs):
+        # create a new version
+        meta = super().put(obj, name, **kwargs)
+        if self._model_version_applies():
+            self._ensure_versioned(meta)
+            meta = self._put_version(meta, tag=tag, commit=commit, previous=previous)
+        return meta
+
+    def get(self, name, commit=None, tag=None, version=-1, **kwargs):
+        if not self._model_version_applies():
+            return super().get(name, **kwargs)
+        meta = self.metadata(name, commit=commit, tag=tag, version=version, **kwargs)
+        actual_name = name
+        if meta:
+            self._ensure_versioned(meta)
+            actual_name = self._model_version_actual_name(name, tag=tag,
+                                                          commit=commit,
+                                                          version=version)
+        return super().get(actual_name, **kwargs)
+
+    def drop(self, name, force=False, version=-1, commit=None, tag=None):
+        # TODO implement drop to support deletion of specific versions
+        if False and self._model_version_applies():
+            # this messes up the version history of the base object!
+            name = self._model_version_actual_name(name, tag=tag, commit=commit, version=version)
+        return super().drop(name, force=force)
+
+    def metadata(self, name, commit=None, tag=None, version=None, raw=False, **kwargs):
+        if not self._model_version_applies():
+            return super().metadata(name, **kwargs)
+        base_meta, base_commit, base_version = self._base_metadata(name, **kwargs)
+        commit = commit or base_commit
+        version = base_version or version or -1
+        if raw and base_meta and 'versions' in base_meta.attributes:
+            actual_name = self._model_version_actual_name(name, tag=tag,
+                                                          commit=commit,
+                                                          version=version)
+            meta = super().metadata(actual_name, **kwargs)
+        else:
+            meta = base_meta
+        return meta
+
+    def revisions(self, name):
+        if self._model_version_applies():
+            meta = self.metadata(name)
+            versions = meta.attributes.get('versions', {})
+            commits = versions.get('commits')
+            tags = versions.get('tags')
+            commit_tags = defaultdict(list)
+            for k, v in tags.items():
+                commit_tags[v].append(k)
+            revisions = [
+                (commit['ref'], commit_tags.get(commit['ref'], ''))
+                for commit in commits
+            ]
+            return revisions
+        raise NotImplementedError
+
+    def _base_metadata(self, name, **kwargs):
+        # return actual name without version tag
+        tag = None
+        version = None
+        if '^' in name:
+            version = -1 * (name.count('^') + 1)
+            name = name.split('^')[0].split('@')[0]
+        elif '@' in name:
+            name, tag = name.split('@')
+        meta = super().metadata(name, **kwargs)
+        return meta, tag, version
+
+    def _model_version_actual_name(self, name, tag=None, commit=None,
+                                   version=None, **kwargs):
+        meta, name_tag, name_version = self._base_metadata(name, **kwargs)
+        tag = tag or name_tag
+        commit = commit or tag
+        version = name_version or version or -1
+        actual_name = meta.name
+        if meta is not None and 'versions' in meta.attributes:
+            # we have an existing versioned object
+            if tag or commit:
+                if tag and tag in meta.attributes['versions']['tags']:
+                    version_hash = meta.attributes['versions']['tags'][tag]
+                    actual_name = self._model_version_store_key(meta.name, version_hash)
+                elif commit:
+                    actual_name = self._model_version_store_key(meta.name, commit)
+                else:
+                    actual_name = name
+            else:
+                if version == -1 or abs(version) <= len(meta.attributes['versions']['commits']):
+                    actual_name = meta.attributes['versions']['commits'][version]['name']
+        return actual_name
+
+    def _model_version_hash(self, meta):
+        hasher = sha1()
+        hasher.update(_u8(meta.name))
+        hasher.update(_u8(str(meta.modified)))
+        return hasher.hexdigest()
+
+    def _model_version_store_key(self, name, version_hash):
+        return '_versions/{}/{}'.format(name, version_hash)
+
+    def _model_version_applies(self):
+        return self.prefix.startswith('models/')
+
+    def _ensure_versioned(self, meta):
+        if 'versions' not in meta.attributes:
+            meta.attributes['versions'] = {}
+            meta.attributes['versions']['tags'] = {}
+            meta.attributes['versions']['commits'] = []
+            meta.attributes['versions']['tree'] = {}
+
+    def _put_version(self, meta, tag=None, commit=None, previous=None):
+        version_hash = commit or self._model_version_hash(meta)
+        previous = meta.attributes['versions']['tags'].get(previous) or previous
+        version_meta = deepcopy(meta)
+        version_meta.id = None
+        version_meta.name = self._model_version_store_key(meta.name, version_hash)
+        del version_meta.attributes['versions']
+        version_meta.save()
+        meta.attributes['versions']['commits'].append(dict(name=version_meta.name, ref=version_hash))
+        meta.attributes['versions']['tree'][version_hash] = previous
+        meta.attributes['versions']['tags']['latest'] = version_hash
+        if tag:
+            meta.attributes['versions']['tags'][tag] = version_hash
+        return meta.save()

--- a/omegaml/restapi/__init__.py
+++ b/omegaml/restapi/__init__.py
@@ -74,6 +74,13 @@ class ModelResource(OmegaResourceMixin, Resource):
         payload = api.payload
         return self._generic_model_resource.put(model_id, query, payload)
 
+    @api.expect(PredictInput, validate=False)
+    @api.marshal_with(PredictOutput)
+    def get(self, model_id):
+        query = flask.request.args
+        payload = api.payload
+        return self._generic_model_resource.put(model_id, query, payload)
+
 
 @api.route('/api/v1/dataset/<string:dataset_id>')
 class DatasetResource(OmegaResourceMixin, Resource):

--- a/omegaml/runtimes/mixins/modelmixin.py
+++ b/omegaml/runtimes/mixins/modelmixin.py
@@ -37,17 +37,17 @@ class ModelMixin(object):
         """
         update the model
 
-        Calls :code:`.partial_fit(X, Y, **kwargs)`. If instead of dataset names actual 
-        data  is given, the data is stored using _fitX/fitY prefixes and 
-        a unique name. 
+        Calls :code:`.partial_fit(X, Y, **kwargs)`. If instead of dataset names actual
+        data  is given, the data is stored using _fitX/fitY prefixes and
+        a unique name.
 
         After fitting, a new model version is stored with its attributes
         fitX and fitY pointing to the datasets, as well as the sklearn
-        version used.   
+        version used.
 
         :param Xname: name of X dataset or data
         :param Yname: name of Y dataset or data
-        :return: the model (self) or the string representation (python clients) 
+        :return: the model (self) or the string representation (python clients)
         """
         omega_fit = self.task('omegaml.tasks.omega_partial_fit')
         Xname = self._ensure_data_is_stored(Xname, prefix='_fitX')
@@ -127,7 +127,7 @@ class ModelMixin(object):
         Xname = self._ensure_data_is_stored(Xpath_or_data)
         return omega_predict_proba.delay(self.modelname, Xname, rName=rName, **kwargs)
 
-    def score(self, Xname, yName, rName=None, **kwargs):
+    def score(self, Xname, Yname=None, rName=None, **kwargs):
         """
         calculate score
 
@@ -142,7 +142,7 @@ class ModelMixin(object):
         """
         omega_score = self.task('omegaml.tasks.omega_score')
         Xname = self._ensure_data_is_stored(Xname)
-        yName = self._ensure_data_is_stored(yName)
+        yName = self._ensure_data_is_stored(Yname)
         return omega_score.delay(self.modelname, Xname, yName, rName=rName, **kwargs)
 
     def decision_function(self, Xname, rName=None, **kwargs):

--- a/omegaml/runtimes/modelproxy.py
+++ b/omegaml/runtimes/modelproxy.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 
 import logging
-from uuid import uuid4
 
-import six
-
-from omegaml.util import is_dataframe, settings, is_ndarray, extend_instance
+from omegaml.util import extend_instance
 
 logger = logging.getLogger(__name__)
 

--- a/omegaml/tasks.py
+++ b/omegaml/tasks.py
@@ -1,5 +1,5 @@
 """
-omega runtime model tasks 
+omega runtime model tasks
 """
 from __future__ import absolute_import
 
@@ -51,7 +51,7 @@ def omega_partial_fit(self,
 
 
 @shared_task(base=OmegamlTask, bind=True)
-def omega_score(self, modelname, Xname, Yname, rName=True, pure_python=True,
+def omega_score(self, modelname, Xname, Yname=None, rName=True, pure_python=True,
                 **kwargs):
     result = self.get_delegate(modelname).score(*self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)

--- a/omegaml/tests/cli/scenarios.py
+++ b/omegaml/tests/cli/scenarios.py
@@ -146,7 +146,7 @@ class CliTestScenarios:
         reg = LinearRegression()
         return om.models.put(reg, 'reg')
 
-    def make_dataset_from_dataframe(self, name, N=100):
+    def make_dataset_from_dataframe(self, name, N=100, m=2, b=0):
         """
         create and store a pandas dataframe
 
@@ -161,7 +161,7 @@ class CliTestScenarios:
             'x': range(N),
             'y': range(N)
         })
-        df['y'] = df['x'] * 2
+        df['y'] = df['x'] * m + b
         return self.om.datasets.put(df, name, append=False)
 
     def create_local_csv(self, path, size=(100, 2), sep=','):

--- a/omegaml/tests/test_modelversions.py
+++ b/omegaml/tests/test_modelversions.py
@@ -1,0 +1,146 @@
+from unittest import TestCase
+
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+from omegaml import Omega
+from omegaml.mixins.store.modelversion import ModelVersionMixin
+from omegaml.tests.util import OmegaTestMixin
+
+
+class ModelVersionMixinTests(OmegaTestMixin, TestCase):
+    def setUp(self):
+        self.om = Omega()
+        self.clean()
+
+    def test_version_on_put(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        clf = LinearRegression()
+        meta = store.put(clf, 'regmodel')
+        self.assertIn('versions', meta.attributes)
+        models = store.list(include_temp=True)
+        latest = meta.attributes['versions']['tags']['latest']
+        store_key = store._model_version_store_key('regmodel', latest)
+        self.assertIn(store_key, models)
+
+    def test_get_version_by_index(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        clf = LinearRegression()
+        clf.version_ = 1
+        meta = store.put(clf, 'regmodel')
+        clf.version_ = 2
+        meta = store.put(clf, 'regmodel')
+        clf_ = store.get('regmodel', version=-1)
+        self.assertEqual(clf_.version_, 2)
+        clf_ = store.get('regmodel', version=-2)
+        self.assertEqual(clf_.version_, 1)
+        clf_ = store.get('regmodel')
+        self.assertEqual(clf_.version_, 2)
+
+    def test_get_version_by_tag(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        clf = LinearRegression()
+        clf.version_ = 1
+        meta = store.put(clf, 'regmodel', tag='version1')
+        clf.version_ = 2
+        meta = store.put(clf, 'regmodel', tag='version2')
+        clf_ = store.get('regmodel', tag='version2')
+        self.assertEqual(clf_.version_, 2)
+        clf_ = store.get('regmodel', tag='version1')
+        self.assertEqual(clf_.version_, 1)
+        clf_ = store.get('regmodel')
+        self.assertEqual(clf_.version_, 2)
+
+    def test_get_version_by_attag(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        clf = LinearRegression()
+        clf.version_ = 1
+        meta = store.put(clf, 'regmodel', tag='version1')
+        clf.version_ = 2
+        meta = store.put(clf, 'regmodel', tag='version2')
+        clf_ = store.get('regmodel@version2')
+        self.assertEqual(clf_.version_, 2)
+        clf_ = store.get('regmodel@version1')
+        self.assertEqual(clf_.version_, 1)
+        clf_ = store.get('regmodel')
+        self.assertEqual(clf_.version_, 2)
+
+    def test_get_version_by_commit(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        clf = LinearRegression()
+        clf.version_ = 1
+        meta = store.put(clf, 'regmodel')
+        clf.version_ = 2
+        meta = store.put(clf, 'regmodel')
+        meta = store.metadata('regmodel')
+        commit1 = meta.attributes['versions']['commits'][-2]['ref']
+        commit2 = meta.attributes['versions']['commits'][-1]['ref']
+        clf_ = store.get('regmodel', commit=commit2)
+        self.assertEqual(clf_.version_, 2)
+        clf_ = store.get('regmodel', commit=commit1)
+        self.assertEqual(clf_.version_, 1)
+        clf_ = store.get('regmodel')
+        self.assertEqual(clf_.version_, 2)
+
+    def test_get_metadata_by_version(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        clf = LinearRegression()
+        clf.version_ = 1
+        meta1 = store.put(clf, 'regmodel', tag='commit1')
+        clf.version_ = 2
+        meta2 = store.put(clf, 'regmodel', tag='commit2')
+        self.assertEqual(meta1.id, meta2.id)
+        meta_commit1_byname = store.metadata(meta2.attributes['versions']['commits'][-2]['name'])
+        meta_commit2_byname = store.metadata(meta2.attributes['versions']['commits'][-1]['name'])
+        meta_commit1_bymeta = store.metadata('regmodel@commit1', raw=True)
+        meta_commit2_bymeta = store.metadata('regmodel@commit2', raw=True)
+        self.assertEqual(meta_commit1_bymeta.id, meta_commit1_byname.id)
+        self.assertEqual(meta_commit2_bymeta.id, meta_commit2_byname.id)
+
+    def test_via_runtime(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        reg = LinearRegression()
+        reg.coef_ = np.array([2])
+        reg.intercept_ = 10
+        store.put(reg, 'regmodel', tag='commit1')
+        reg.coef_ = np.array([5])
+        reg.intercept_ = 0
+        store.put(reg, 'regmodel', tag='commit2')
+        # via past version pointer
+        r1 = self.om.runtime.model('regmodel^').predict([10]).get()
+        r2 = self.om.runtime.model('regmodel').predict([10]).get()
+        self.assertEqual(r1[0], 10 * 2 + 10)
+        self.assertEqual(r2[0], 10 * 5 + 0)
+        # via version tag
+        r1 = self.om.runtime.model('regmodel@commit1').predict([10]).get()
+        r2 = self.om.runtime.model('regmodel@commit2').predict([10]).get()
+        self.assertEqual(r1[0], 10 * 2 + 10)
+        self.assertEqual(r2[0], 10 * 5 + 0)
+
+    def test_nonexistent(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        store.metadata('nonexistent')
+        store.get('nonexistent')
+
+    def test_dropversion(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        reg = LinearRegression()
+        reg.coef_ = np.array([2])
+        reg.intercept_ = 10
+        store.put(reg, 'regmodel', tag='commit1')
+        reg.coef_ = np.array([5])
+        reg.intercept_ = 0
+        store.put(reg, 'regmodel', tag='commit2')
+
+
+
+

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -100,7 +100,7 @@ def settings(reload=False):
             if k.isupper() and not hasattr(defaults, k):
                 setattr(defaults, k, getattr(omdefaults, k))
     __settings = defaults
-    return __settings
+    return DefaultsContext(__settings)
 
 
 def override_settings(**kwargs):


### PR DESCRIPTION
this enables automated model versioning

Model versioning and multi-model deployment is not new to omegaml but before this required explicit versioning by name.

* the ModelVersion plugin automatically versions models, keeping all versioning accessible from the same Metadata entry
* each model version is represented as its own object, allowing for diffs both across the model itself as well as it the Metadata
* each model version remembers specifics such as gridsearch results, what data and features it was fitted against etc.
* model versioning is transparent to all APIs as it is implemented as an extension to the model store, not as part of a particular backend
* multiple versions can be run at the same time using the runtime api