### PR TITLE
add externaldata backend, jobs returns metadata repr, easier rawfiles export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,5 @@ build_sdist.out
 nohup.out
 /omegaml/tests/test.db
 /test.db
+/foobar.db
+/user.db

--- a/omegaml/backends/externaldata.py
+++ b/omegaml/backends/externaldata.py
@@ -1,0 +1,130 @@
+import six
+
+from omegaml.backends.basedata import BaseDataBackend
+import pandas as pd
+
+
+class PandasExternalData(BaseDataBackend):
+
+    """
+    external data is stored as a uri on some external medium
+    """
+    SCHEMES = ['http', 'ftp', 'file', 's3']
+    KIND = 'pandas.csv'
+
+    @classmethod
+    def supports(cls, obj, name, **kwargs):
+        supported_scheme = _is_supported_scheme(obj, **kwargs)
+        supported_type = _is_supported_type(obj, **kwargs)
+        return supported_scheme | supported_type
+
+    def put(self, obj, name, attributes=None, **kwargs):
+        """
+        Store external data (currently only csv)
+
+        This supports various pandas file sources as:
+
+        * storing the URI to an external csv file
+        * storing a pd.DataFrame, pd.Series, as a csv, at an external URI
+        * copying an external CSV from one URI to another URI
+
+        Only URIs implemented by pandas.read_csv() are supported to store
+        the URI (http, ftp, file, s3). Only s3 and local files are supported
+        to copy a csv file from either a supported URI or from an object 
+        into a csv on s3 or on the local file system.
+
+        Examples:
+
+        # store a reference to S3
+        om.datasets.put('s3://bucket/test/google.csv', 'google-s3')
+        # from dataframe direcly to s3
+        om.datasets.put(df, 'google-s3', uri='s3://bucket/test/google.csv')
+        # from s3 into mongodb
+        om.datasets.put(None, 'google-mongo', uri='s3://bucket/test/google.csv')
+        # from dataframe to local
+        om.datasets.put(df, 'google-local', uri='file:///tmp/google.csv')
+        # from local directly to s3
+        om.datasets.put('s3://bucket/test/google2.csv', 
+        'google-s3-direct', uri='file:///tmp/google.csv')
+
+        :param obj: (str|pd.Series|pd.DataFrame) the object to store. If str
+          must be URI of the form scheme://location/name.csv where scheme
+          is one of the upported schemes by pandas.read_csv
+        :param name: (str) the name of the object in the store
+        :param attributes: custom attributes to store with the object
+        """
+        uri = kwargs.get('uri')
+        # case object is a supported uri, e.g. s3://bucket/name.ext
+        if _is_supported_scheme(obj, **kwargs):
+            if uri is None:
+                # store object as a location pointer with given name
+                metadata = self.data_store.make_metadata(name, self.KIND,
+                                                         attributes=attributes)
+                metadata.uri = obj
+            else:
+                # read object, store in given location
+                # then store as a location pointer with given name
+                df = pd.read_csv(uri)
+                metadata = self.data_store.put(df, name, uri=obj,
+                                               attributes=attributes)
+        # case object is a supported object type
+        elif _is_supported_type(obj, **kwargs) and uri:
+            # if object is None we read the file from the URI first
+            if obj is None:
+                obj = pd.read_csv(uri)
+            # convert to CSV data
+            data = obj.to_csv()
+            # store in supported location
+            if uri.startswith('s3://'):
+                import s3fs
+                data = obj.to_csv()
+                fs = s3fs.S3FileSystem()
+                with fs.open(uri, 'wb') as fout:
+                    fout.write(data.encode(encoding='utf-8'))
+                metadata = self.data_store.make_metadata(
+                    name, self.KIND, attributes=attributes)
+                metadata.uri = uri
+            elif uri.startswith('file'):
+                obj.to_csv(uri.replace('file://', ''))
+                metadata = self.data_store.make_metadata(
+                    name, self.KIND, attributes=attributes)
+                metadata.uri = uri
+            # case erroneous
+            else:
+                raise ValueError(
+                    ('Not supported type obj={} with '
+                     'name={} and uri={}').format(type(obj), name, uri))
+        # case erroneous parameters
+        else:
+            raise ValueError(('Not supported type obj={} '
+                              'with name={}').format(type(obj), name))
+        return metadata.save()
+
+    def get(self, name, version=-1, force_python=False, lazy=False, **kwargs):
+        """
+        Get a csv stored at an external location
+        """
+        meta = self.data_store.metadata(name)
+        read_kwargs = dict(usecols=kwargs.get('columns'))
+        read_kwargs.update(kwargs.get('pandas_kwargs', {}))
+        df = pd.read_csv(meta.uri, **read_kwargs)
+        return df
+
+
+def _is_supported_scheme(obj, **kwargs):
+    if isinstance(obj, six.string_types):
+        parts = obj.split('://')
+        if len(parts) > 1:
+            scheme, loc = parts
+            return scheme in PandasExternalData.SCHEMES
+    elif obj is None and kwargs.get('uri') is not None:
+        return True
+    return False
+
+
+def _is_supported_type(obj, **kwargs):
+    uri = kwargs.get('uri')
+    supported_type = isinstance(obj, (pd.Series, pd.DataFrame))
+    supported_scheme = _is_supported_scheme(uri)
+    return supported_type & supported_scheme
+

--- a/omegaml/backends/rawfiles.py
+++ b/omegaml/backends/rawfiles.py
@@ -1,5 +1,5 @@
 import os
-import six
+from os.path import dirname, basename
 
 from omegaml.backends.basedata import BaseDataBackend
 
@@ -15,8 +15,32 @@ class PythonRawFileBackend(BaseDataBackend):
         is_filelike = hasattr(obj, 'read')
         return is_filelike or self._is_path(self, obj)
 
-    def get(self, name, version=-1, lazy=False, **kwargs):
-        return self.data_store.metadata(name, **kwargs).gridfile
+    def get(self, name, local=None, **kwargs):
+        """
+        get a stored file as a file handler with binary contents or a local file
+
+        Args:
+            name (str): the name of the file
+            local (str): if set the local path will be created and the file
+               stored there. If local does not have an extension it is assumed
+               to be a directory name, in which case the file is stored as the
+               same name.
+            **kwargs:
+
+        Returns:
+            the file-like output handler (local is None)
+            the path to the local file (local is given)
+        """
+        outf = self.data_store.metadata(name, **kwargs).gridfile
+        if local:
+            is_filename = '.' in basename(local)
+            target_dir = dirname(local) if is_filename else local
+            local = local if is_filename else '{local}/{name}'.format(**locals())
+            os.makedirs(target_dir, exist_ok=True)
+            with open(local, 'wb') as flocal:
+                flocal.write(outf.read())
+            return local
+        return outf
 
     def put(self, obj, name, attributes=None, encoding=None, **kwargs):
         self.data_store.drop(name, force=True)

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -81,6 +81,7 @@ OMEGA_STORE_BACKENDS = {
     'pandas.rawdict': 'omegaml.backends.rawdict.PandasRawDictBackend',
     'python.file': 'omegaml.backends.rawfiles.PythonRawFileBackend',
     'python.package': 'omegaml.backends.package.PythonPackageData',
+    'pandas.csv': 'omegaml.backends.externaldata.PandasExternalData',
 }
 OMEGA_STORE_BACKENDS_TENSORFLOW = {
     'tfkeras.h5': 'omegaml.backends.tensorflow.TensorflowKerasBackend',

--- a/omegaml/notebook/tasks.py
+++ b/omegaml/notebook/tasks.py
@@ -59,7 +59,7 @@ def run_omegaml_job(self, nb_file, event=None, **kwargs):
     runs omegaml job
     """
     result = self.om.jobs.run_notebook(nb_file, event=event)
-    return result.to_json()
+    return sanitized(result)
 
 
 @shared_task(base=NotebookTask, bind=True)

--- a/omegaml/tests/test_jobs.py
+++ b/omegaml/tests/test_jobs.py
@@ -1,5 +1,3 @@
-
-
 from __future__ import absolute_import
 
 from datetime import timedelta
@@ -9,6 +7,7 @@ import gridfs
 from nbformat import v4
 
 from omegaml import Omega
+from omegaml.documents import Metadata
 from omegaml.notebook.jobs import JobSchedule
 from omegaml.util import settings as omegaml_settings, settings
 
@@ -82,10 +81,12 @@ class JobTests(TestCase):
         meta = om.jobs.put(notebook, 'testjob')
         self.assertEqual(meta.name, 'testjob.ipynb')
         meta_job = om.jobs.run('testjob')
-        self.assertIn('job_results', meta_job.attributes)
-        self.assertIn('job_runs', meta_job.attributes)
-        runs = meta_job.attributes['job_runs']
-        results = meta_job.attributes['job_results']
+        self.assertIsInstance(meta_job, Metadata)
+        meta = om.jobs.put(notebook, 'testjob')
+        self.assertIn('job_results', meta.attributes)
+        self.assertIn('job_runs', meta.attributes)
+        runs = meta.attributes['job_runs']
+        results = meta.attributes['job_results']
         self.assertEqual(len(runs), 1)
         self.assertEqual(len(results), 1)
         resultnb = results[0]
@@ -105,9 +106,11 @@ class JobTests(TestCase):
         meta = om.jobs.put(notebook, 'testjob')
         # -- execute with default timeout, expect to succeed
         meta_job = om.jobs.run('testjob')
-        runs = meta_job.attributes['job_runs']
-        results = meta_job.attributes['job_results']
-        self.assertIn('job_runs', meta_job.attributes)
+        self.assertIsInstance(meta_job, Metadata)
+        meta = om.jobs.metadata('testjob')
+        runs = meta.attributes['job_runs']
+        results = meta.attributes['job_results']
+        self.assertIn('job_runs', meta.attributes)
         self.assertEqual(len(results), 1)
         resultnb = results[0]
         self.assertTrue(om.jobs.exists(resultnb))
@@ -120,8 +123,10 @@ class JobTests(TestCase):
         meta.save()
         self.assertEqual(meta.name, 'testjob.ipynb')
         meta_job = om.jobs.run('testjob')
-        self.assertIn('job_runs', meta_job.attributes)
-        runs = meta_job.attributes['job_runs']
+        self.assertIsInstance(meta_job, Metadata)
+        meta = om.jobs.metadata('testjob')
+        self.assertIn('job_runs', meta.attributes)
+        runs = meta.attributes['job_runs']
         this_run = runs[0]
         self.assertEqual(this_run['status'], 'ERROR')
         self.assertIn('execution timed out', this_run['message'])
@@ -132,9 +137,11 @@ class JobTests(TestCase):
         meta.kind_meta['ep_kwargs'] = dict(timeout=None)
         meta.save()
         meta_job = om.jobs.run('testjob')
-        runs = meta_job.attributes['job_runs']
-        results = meta_job.attributes['job_results']
-        self.assertIn('job_runs', meta_job.attributes)
+        self.assertIsInstance(meta_job, Metadata)
+        meta = om.jobs.metadata('testjob')
+        runs = meta.attributes['job_runs']
+        results = meta.attributes['job_results']
+        self.assertIn('job_runs', meta.attributes)
         self.assertEqual(len(results), 1)
         resultnb = results[0]
         self.assertTrue(om.jobs.exists(resultnb))
@@ -156,7 +163,9 @@ class JobTests(TestCase):
         self.assertEqual(meta.name, 'testjob.ipynb')
         nb = v4.new_notebook(cells=cells)
         meta_job = om.jobs.run('testjob')
-        runs = meta_job.attributes['job_runs']
+        self.assertIsInstance(meta_job, Metadata)
+        meta = om.jobs.put(notebook, 'testjob')
+        runs = meta.attributes['job_runs']
         self.assertEqual(len(runs), 1)
         self.assertEqual('ERROR', runs[0]['status'])
 
@@ -438,6 +447,3 @@ class JobTests(TestCase):
         self.assertEqual(sched.text, 'At 06:00 AM, Monday through Friday')
         sched = JobSchedule('every 2nd hour, 5 minute, weekdays')
         self.assertEqual(sched.text, 'At 5 minutes past the hour, every 2 hours, Monday through Friday')
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,12 @@ else:
     tf_deps = ['tensorflow>={}'.format(tf_version)]
     keras_deps = ['keras>=2.4.3']
 
+# all deps
+all_deps = (hdf_deps + tf_deps + keras_deps + graph_deps + dashserve_deps
+            + sql_deps + iotools_deps + streaming_deps + jupyter_deps + snowflake_deps)
+all_client_deps = (hdf_deps + dashserve_deps + sql_deps + iotools_deps + streaming_deps)
+
+
 setup(
     name='omegaml',
     version=version,


### PR DESCRIPTION
various enhancements  following community feedback
- externaldata moved from omegaml ee edition to core
- rawfiles improved to enable local path output using get(...,
local=path)
- job run now clears notebook output and stores resulting notebook in
error and ok states (previously only ok states were stored)
- runtime job run returns repr(metadata) instead of full metadata object
like other tasks