### PR TITLE
Create NOSELLCLAUSE

### DIFF
--- a/NOSELLCLAUSE
+++ b/NOSELLCLAUSE
@@ -1,0 +1,16 @@
+“No Sell, Consulting Yes” License Condition v1.1
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, 
+and the License does not grant to you, right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License 
+to provide to third parties, for a fee or other consideration (including without limitation fees for hosting Software), 
+a product or service whose value derives, entirely or substantially, from the functionality of the Software. 
+
+Any license notice or attribution required by the License must also include this Commons Cause License Condition notice.
+
+Software: omega|ml
+License: Apache 2.0
+Licensor: one2seven GmbH, Hagenholzstr. 83b, Zuerich, Switzerland


### PR DESCRIPTION
This is derived from the Commons Clause, however permissions professional and consulting services. It does not permit providing omega|ml as a service.