### PR TITLE
various updates

### DIFF
--- a/omegaml/mixins/store/promotion.py
+++ b/omegaml/mixins/store/promotion.py
@@ -30,8 +30,12 @@ class PromotionMixin(object):
             The Metadata of the new object
         """
         drop = drop if drop is not None else self.DEFAULT_DROP.get(self.prefix, True)
-        if self == other:
-            raise ValueError('cannot promote to self')
+        # sanity checks
+        # -- promotion by same name requires a different store
+        meta = self.metadata(name)
+        asname = asname or meta.name
+        if name == asname and self == other:
+            raise ValueError(f'must specify asname= different from {meta.name}')
         # see if the backend supports explicit promotion
         backend = self.get_backend(name)
         if hasattr(backend, 'promote'):

--- a/omegaml/notebook/tasks.py
+++ b/omegaml/notebook/tasks.py
@@ -15,42 +15,50 @@ class NotebookTask(OmegamlTask):
     abstract = True
 
     def on_success(self, retval, task_id, *args, **kwargs):
-        om = self.om
-        args, kwargs = args[0:2]
-        nbfile = args[0]
-        meta = om.jobs.metadata(nbfile)
-        attrs = meta.attributes
-        attrs['state'] = 'SUCCESS'
-        attrs['task_id'] = task_id
-        meta.kind = MDREGISTRY.OMEGAML_JOBS
+        super().on_success(retval, task_id, *args, **kwargs)
+        try:
+            om = self.om
+            args, kwargs = args[0:2]
+            nbfile = args[0]
+            meta = om.jobs.metadata(nbfile)
+            attrs = meta.attributes
+            attrs['state'] = 'SUCCESS'
+            attrs['task_id'] = task_id
+            meta.kind = MDREGISTRY.OMEGAML_JOBS
 
-        if not kwargs:
+            if not kwargs:
+                pass
+            else:
+                attrs['last_run_time'] = kwargs.get('run_at')
+                attrs['next_run_time'] = kwargs.get('next_run_time')
+
+            meta.attributes = attrs
+            meta.save()
+        except:
             pass
-        else:
-            attrs['last_run_time'] = kwargs.get('run_at')
-            attrs['next_run_time'] = kwargs.get('next_run_time')
-
-        meta.attributes = attrs
-        meta.save()
 
     def on_failure(self, retval, task_id, *args, **kwargs):
-        om = self.om
-        args, kwargs = args[0:2]
-        nbfile = args[0]
-        meta = om.jobs.metadata(nbfile)
-        attrs = meta.attributes
-        attrs['state'] = 'FAILURE'
-        attrs['task_id'] = task_id
-        meta.kind = MDREGISTRY.OMEGAML_JOBS
+        super().on_failure(retval, task_id, *args, **kwargs)
+        try:
+            om = self.om
+            args, kwargs = args[0:2]
+            nbfile = args[0]
+            meta = om.jobs.metadata(nbfile)
+            attrs = meta.attributes
+            attrs['state'] = 'FAILURE'
+            attrs['task_id'] = task_id
+            meta.kind = MDREGISTRY.OMEGAML_JOBS
 
-        if not kwargs:
+            if not kwargs:
+                pass
+            else:
+                attrs['last_run_time'] = kwargs.get('run_at')
+                attrs['next_run_time'] = kwargs.get('next_run_time')
+
+            meta.attributes = attrs
+            meta.save()
+        except:
             pass
-        else:
-            attrs['last_run_time'] = kwargs.get('run_at')
-            attrs['next_run_time'] = kwargs.get('next_run_time')
-
-        meta.attributes = attrs
-        meta.save()
 
 
 @shared_task(bind=True, base=NotebookTask)

--- a/omegaml/tests/core/restapi/test_model_api.py
+++ b/omegaml/tests/core/restapi/test_model_api.py
@@ -60,6 +60,24 @@ class OmegaRestApiTests(OmegaTestMixin, TestCase):
         self.assertEqual(data.get('model'), 'regression')
         self.assertEqual(data.get('result'), [10.])
 
+    def test_predict_from_dataset_complex_modelpath(self):
+        X = np.arange(10).reshape(-1, 1)
+        y = X * 2
+        # train model locally
+        clf = LinearRegression()
+        clf.fit(X, y)
+        result = clf.predict(X)
+        # store model in om
+        self.om.models.put(clf, 'project/test/regression')
+        self.om.datasets.put([5], 'project/test/foo', append=False)
+        # check we can use it to predict
+        resp = self.client.put('/api/v1/model/project/test/regression/predict?datax=project/test/foo',
+                               json={}, auth = self.auth, headers=self._headers)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertEqual(data.get('model'), 'project/test/regression')
+        self.assertEqual(data.get('result'), [10.])
+
     def test_dataset_query(self):
         om = self.om
         df = pd.DataFrame({

--- a/omegaml/tests/core/test_promotion.py
+++ b/omegaml/tests/core/test_promotion.py
@@ -132,6 +132,16 @@ class PromotionMixinTests(OmegaTestMixin, TestCase):
         with self.assertRaises(ValueError):
             om.datasets.promote('foo', om.datasets)
 
+    def test_promotion_to_self_asname(self):
+        om = self.om
+        reg = LinearRegression()
+        om.models.put(reg, 'dev/mymodel')
+        om.models.promote('dev/mymodel', om.models, asname='prod/mymodel')
+        self.assertIn('prod/mymodel', om.models.list())
+        om.datasets.put(['foo'], 'dev/foo')
+        om.datasets.promote('dev/foo', om.datasets, asname='prod/foo')
+        self.assertIn('prod/foo', om.datasets.list())
+
     def test_promotion_to_other_db_works(self):
         om = self.om
         other = Omega(mongo_url=om.mongo_url + '_promotest')

--- a/omegaml/tests/core/test_tracking.py
+++ b/omegaml/tests/core/test_tracking.py
@@ -127,7 +127,7 @@ class TrackingTestCases(OmegaTestMixin, unittest.TestCase):
         self.assertIsNotNone(data)
         self.assertEqual(len(data), 6)
 
-    def test_tracking_predictions(self):
+    def test_tracking_predictions_explicit_metadata(self):
         # create a model
         om = self.om
         iris = load_iris()
@@ -146,6 +146,29 @@ class TrackingTestCases(OmegaTestMixin, unittest.TestCase):
         data = exp.data()
         self.assertIsNotNone(data)
         self.assertEqual(len(data), 6)
+
+    def test_tracking_predictions_implicit_tracker(self):
+        # create a model
+        om = self.om
+        iris = load_iris()
+        X = iris.data
+        Y = iris.target
+        lr = LogisticRegression(solver='liblinear', multi_class='auto')
+        lr.fit(X, Y)
+        om.models.put(lr, 'mymodel')
+        tracker = om.runtime.experiment('expfoo')
+        tracker.track('mymodel')
+        om.runtime.model('mymodel').score(X, Y)
+        exp = tracker.experiment
+        data = exp.data()
+        self.assertIsNotNone(data)
+        self.assertEqual(len(data), 6)
+        # run a prediction to see if this is tracked
+        om.runtime.model('mymodel').predict(X)
+        tracker = om.runtime.experiment('expfoo')
+        data = exp.data()
+        self.assertIsNotNone(data)
+        self.assertEqual(len(data), 9)
 
     def test_empty_experiment_data(self):
         om = self.om


### PR DESCRIPTION
- experiments now provide a .track(model) method to easily update model
default tracking
- promotion of models to same store works as long as with different
names
- job task handlers now catch errors silently
- task parallel results provide .collect() and .getall() results to
easily return parent tasks
- runtime.require('local') is equivalent to runtime.local(mode=True)
- add tests