### PR TITLE
Performance gains

### DIFF
--- a/omegaml/__init__.py
+++ b/omegaml/__init__.py
@@ -1,3 +1,4 @@
+import cachetools
 import logging
 
 from omegaml import defaults as _base_config
@@ -7,6 +8,7 @@ from omegaml.omega import OmegaDeferredInstance
 from omegaml.util import load_class, settings, base_loader
 
 logger = logging.getLogger(__file__)
+
 
 # link implementation
 def link(_omega):
@@ -51,3 +53,5 @@ streams = _omega.OmegaDeferredInstance(_omega._om, 'streams')
 logger = _omega.OmegaDeferredInstance(_omega._om, 'logger')
 #: the settings object
 defaults = _omega.OmegaDeferredInstance(_omega._om, 'defaults')
+#: session cache
+session_cache = cachetools.cached(cache=cachetools.TTLCache(**getattr(_base_config, 'OMEGA_SESSION_CACHE')))

--- a/omegaml/backends/package/tasks.py
+++ b/omegaml/backends/package/tasks.py
@@ -62,7 +62,7 @@ def run_omega_script(self, scriptname, **kwargs):
         'python': lambda v: v,
     }
 
-    format = kwargs.get('__format') or 'json'
+    format = self.system_kwargs.get('__format') or 'json'
     mod = self.om.scripts.get(scriptname)
     dtstart = datetime.datetime.now()
     try:
@@ -96,4 +96,8 @@ def run_omega_callback_script(self, *args, **kwargs):
         results = args[0]
         state = 'SUCCESS'
         scriptname = args[-1]
-    return run_omega_script(scriptname, state=state, results=results, **kwargs)
+    # include hidden (__key=value) kwargs, e.g. for logging, bucket, experiment
+    # so that the run_omega_script task context sets up a proper omega instance
+    full_kwargs = kwargs
+    full_kwargs.update(self.system_kwargs)
+    return run_omega_script(scriptname, state=state, results=results, **full_kwargs)

--- a/omegaml/client/auth.py
+++ b/omegaml/client/auth.py
@@ -1,17 +1,20 @@
 # source https://djangosnippets.org/snippets/2727/
-import os
 
 from requests.auth import AuthBase
+
+from omegaml import session_cache
 
 
 class AuthenticationEnv(object):
     @classmethod
+    @session_cache  # PERFTUNED
     def get_omega_for_task(cls, auth=None):
         from omegaml import Omega
         om = Omega()
         return om
 
     @classmethod
+    @session_cache  # PERFTUNED
     def get_omega_from_apikey(cls, *args, **kwargs):
         from omegaml import Omega
         om = Omega()
@@ -69,6 +72,7 @@ class OmegaRuntimeAuthentication:
 
 class OmegaSecureAuthenticationEnv(AuthenticationEnv):
     @classmethod
+    @session_cache
     def get_omega_for_task(cls, auth=None):
         """
         Get Omega instance configured for user in auth
@@ -116,9 +120,10 @@ class OmegaSecureAuthenticationEnv(AuthenticationEnv):
         return om
 
     @classmethod
+    @session_cache  # PERFTUNED
     def get_omega_from_apikey(cls, *args, **kwargs):
         from omegaml.client.userconf import get_omega_from_apikey
         return get_omega_from_apikey(*args, **kwargs)
 
-isTrue = lambda v: v if isinstance(v, bool) else (
-    v.lower() in ['yes', 'y', 't', 'true', '1'])
+
+isTrue = lambda v: v if isinstance(v, bool) else (v.lower() in ['yes', 'y', 't', 'true', '1'])

--- a/omegaml/client/cli/runtime.py
+++ b/omegaml/client/cli/runtime.py
@@ -28,7 +28,7 @@ class RuntimeCommandBase(CommandBase):
       om runtime status [workers|labels|stats] [options]
       om runtime restart app <name> [--insecure] [options]
       om runtime serve [<rule>...] [--rules=<rulefile>] [options]
-      om runtime (control|inspect|celery) [<celery-command>...] [--worker=<worker>] [--queue=<queue>] [--celery-help] [--flags <celery-flags>...] [options]
+      om runtime (control|inspect|celery) [<celery-command>...] [--worker=<worker>] [--queue=<queue>] [--celery-help] [--flags <celery-flags>] [options]
       om runtime (export|import) [<prefix/name>...] [--path=<path>] [--compress] [--list] [--promote] [options]
 
       Options:
@@ -304,7 +304,7 @@ class RuntimeCommandBase(CommandBase):
                 if kind == 'value':
                     celery_cmds += [self.args.get(opt)]
         celery_cmds += self.args.get('<celery-command>')
-        celery_cmds += self.args.get('--flags')
+        celery_cmds += self.args.get('--flags').split(' ')
         if len(celery_cmds) == 1 + int(action is not None):
             celery_cmds += ['--help']
         # start in-process for speed

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -176,7 +176,11 @@ OMEGA_TRACKING_PROVIDERS = {
     'profiling': 'omegaml.backends.experiment.OmegaProfilingTracker',
     'notrack': 'omegaml.backends.experiment.NoTrackTracker',
 }
-
+#: session cache settings for cachetools.TTLCache
+OMEGA_SESSION_CACHE = {
+    'maxsize': 1, # cache at most one session
+    'ttl': 3600,  # keep it for 1 hour
+}
 
 # =========================================
 # ----- DO NOT MODIFY BELOW THIS LINE -----

--- a/omegaml/example/demo/helloworld/helloworld/__init__.py
+++ b/omegaml/example/demo/helloworld/helloworld/__init__.py
@@ -9,10 +9,10 @@ def run(om, **kwargs):
     """
     import pandas as pd
     df = pd.DataFrame({
-        'a': list(range(0, int(1e6 + 1))),
-        'b': list(range(0, int(1e6 + 1)))
+        'a': list(range(0, int(1e3 + 1))),
+        'b': list(range(0, int(1e3 + 1)))
     })
     store = om.datasets
-    store.put(df, 'mydata-xlarge', append=False, chunksize=50000)
+    store.put(df, 'mydata-xlarge', append=False, chunksize=100)
     result = hello(**kwargs)
     return result

--- a/omegaml/omega.py
+++ b/omegaml/omega.py
@@ -1,6 +1,4 @@
 import os
-import sys
-import warnings
 from uuid import uuid4
 
 from ._version import version
@@ -153,10 +151,12 @@ class OmegaDeferredInstance(object):
         omega = None
         from_env = {'OMEGA_USERID', 'OMEGA_APIKEY'} < set(os.environ)
         from_config = 'OMEGA_CONFIG_FILE' in os.environ or os.path.exists('config.yml')
-        loaders = setup_env, setup_cloud_config, setup_base
+        loaders = (from_env, setup_env), (from_config, setup_cloud_config), (True, setup_base)
         must_load = (from_env, setup_env), (from_config, setup_cloud_config)
         errors = []
-        for loader in loaders:
+        for condition, loader in loaders:
+            if not condition:
+                continue
             try:
                 omega = loader()
             except Exception as e:
@@ -204,7 +204,7 @@ def setup(*args, **kwargs):
 
 
 # dynamic lookup of Omega instance in a task context
-get_omega_for_task = lambda task: _om.setup()
+get_omega_for_task = (lambda task: _om.setup())
 
 # default instance
 # -- these are deferred instanced that is the actual Omega instance

--- a/omegaml/runtimes/runtime.py
+++ b/omegaml/runtimes/runtime.py
@@ -197,18 +197,23 @@ class OmegaRuntime(object):
         Returns:
             self
         """
-        if label == 'local':
-            return self.mode(local=True)
-        routing = routing or {
-            'label': label or self._default_label
-        }
-        task = task or {}
-        if always:
-            self._task_default_kwargs['routing'].update(routing)
-            self._task_default_kwargs['task'].update(task)
-        else:
-            self._require_kwargs['routing'].update(routing)
-            self._require_kwargs['task'].update(task)
+        if label is not None:
+            if label == 'local':
+                self.mode(local=True)
+            else:
+                self.mode(local=False)
+            routing = routing or {
+                'label': label or self._default_label
+            }
+        if task or routing:
+            task = task or {}
+            routing = routing or {}
+            if always:
+                self._task_default_kwargs['routing'].update(routing)
+                self._task_default_kwargs['task'].update(task)
+            else:
+                self._require_kwargs['routing'].update(routing)
+                self._require_kwargs['task'].update(task)
         return self
 
     def model(self, modelname, require=None):

--- a/omegaml/store/fastinsert.py
+++ b/omegaml/store/fastinsert.py
@@ -23,15 +23,10 @@ def insert_chunk(job):
                 should include the database name, as the collection is taken
                 from the default database of the connection.
     """
+    # note we do not catch exceptions as we want to propagate errors back to caller
+    # rationale: if one chunk insert fails, all should fail and user be notified
     sdf, collection, cpid = job
-    try:
-        result = collection.insert_many(sdf.to_dict(orient='records'))
-    finally:
-        if getattr(collection, '_pkl_cloned', True):
-            # only close if this is a cloned connection
-            # this to avoid invalidating original calling MongoClient
-            # (InvalidOperation: Cannot use MongoClient after close)
-            collection.database.client.close()
+    result = collection.insert_many(sdf.to_dict(orient='records'))
     return len(result.inserted_ids)
 
 

--- a/omegaml/store/streams.py
+++ b/omegaml/store/streams.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 from hashlib import md5
 from mongoengine import DoesNotExist
 
@@ -92,7 +91,6 @@ class StreamsProxy(OmegaStore):
             stream = mb.streaming(stream_name, **kwargs, cnx_kwargs=self._stream_kwargs)
         return stream
 
-    @lru_cache(maxsize=None)
     def _cached_get(self, name, reload=False, _cachex=None):
         if reload:
             # force to avoid cache

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -1042,3 +1042,5 @@ class IterableJsonDump(list):
         buffer = StringIO()
         cls.dump(iterlike, buffer, **kwargs)
         return buffer.getvalue()
+
+

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
         'smart_open', # required in cli
         'imageio>=2.3.0', # require to store images
         'psutil>=5.8' # required for profiling tracker
+        'cachetools>=5.0.0' # required for session caching
     ],
     extras_require={
         'graph': graph_deps,


### PR DESCRIPTION
this improves on several performance related aspects

* worker performance: by enabling caching of omega instances. configurable in defaults.OMEGA_SETTINGS_CACHE
* session loading: load smarter, avoiding irrelevant tests

to keep ci going, also fixes 
* mlflow latest release caused failures on task exit, invalidating tests even though they ran ok
* pymongo changes in pooling caused fastinsert to attempt reusing closed connections in PickledCollection