### PR TITLE
fup to auth env refactorign, upgrades of pymongo, performance tuning

### DIFF
--- a/docs/source/nb/omegaml-tutorial.ipynb
+++ b/docs/source/nb/omegaml-tutorial.ipynb
@@ -391,11 +391,11 @@
    "source": [
     "# use the model REST API \n",
     "import requests\n",
-    "from omegaml.client.auth import OmegaRestApiAuth\n",
+    "from omegaml.client.auth import AuthenticationEnv\n",
     "import omegaml as om \n",
     "\n",
     "# -- setup authentication and API URL\n",
-    "auth = OmegaRestApiAuth.make_from(om)\n",
+    "auth = AuthenticationEnv.secure().get_restapi_auth(om=om)\n",
     "url = getattr(om.defaults, 'OMEGA_RESTAPI_URL', 'http://localhost:5000')\n",
     "modelname = 'iris-model'\n",
     "dataset = 'iris'\n",

--- a/omegaml/__init__.py
+++ b/omegaml/__init__.py
@@ -7,8 +7,10 @@ from omegaml._version import version
 from omegaml.omega import OmegaDeferredInstance
 from omegaml.util import load_class, settings, base_loader
 
-logger = logging.getLogger(__file__)
-
+# session cache must be defined here globally so can be imported from anywhere
+# without causing circular import issues
+#: session cache
+session_cache = cachetools.cached(cache=cachetools.TTLCache(**_base_config.OMEGA_SESSION_CACHE))
 
 # link implementation
 def link(_omega):
@@ -29,7 +31,6 @@ def link(_omega):
 # load base and lazy link
 # -- base_loader only loads classes, does not instantiate
 # -- deferred instance provides setup to load and link on access
-session_cache = cachetools.cached(cache=cachetools.TTLCache(**getattr(_base_config, 'OMEGA_SESSION_CACHE')))
 _omega = base_loader(_base_config)
 setup = _omega.setup
 version = getattr(_omega, 'version', version)

--- a/omegaml/client/auth.py
+++ b/omegaml/client/auth.py
@@ -1,6 +1,7 @@
 from requests.auth import AuthBase
 
-from omegaml import session_cache, load_class, settings
+from omegaml import session_cache
+from omegaml.util import load_class, settings
 
 
 class OmegaRestApiAuth(AuthBase):

--- a/omegaml/client/cloud.py
+++ b/omegaml/client/cloud.py
@@ -77,10 +77,12 @@ class OmegaCloudRuntime(OmegaRuntime):
         return account_routing
 
 
-def setup(userid=None, apikey=None, api_url=None, qualifier=None, bucket=None):
+def setup(userid=None, apikey=None, api_url=None, qualifier=None, bucket=None,
+          view=None):
     import omegaml as om_mod
     api_url = ensure_api_url(api_url, om_mod._base_config)
-    view = getattr(om_mod._base_config, 'OMEGA_SERVICES_INCLUSTER', False)
+    view = (view if view is not None
+            else getattr(om_mod._base_config, 'OMEGA_SERVICES_INCLUSTER', False))
     auth_env = AuthenticationEnv.secure()
     om = auth_env.get_omega_from_apikey(userid=userid, apikey=apikey,
                                         api_url=api_url, qualifier=qualifier, view=view)

--- a/omegaml/client/userconf.py
+++ b/omegaml/client/userconf.py
@@ -108,7 +108,8 @@ def _get_omega_from_apikey(userid, apikey, api_url=None, requested_userid=None,
     auth_env = AuthenticationEnv.secure()
     if api_url.startswith('http') or any('test' in v for v in sys.argv):
         configs = auth_env.get_userconfig_from_api(requested_userid=requested_userid,
-                                                   view=view, defaults=defaults)
+                                                   api_url=api_url, view=view,
+                                                   defaults=defaults)
         configs = configs['objects'][0]['data']
     elif api_url == 'local':
         configs = {k: getattr(defaults, k) for k in dir(defaults) if k.startswith('OMEGA')}

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -34,7 +34,7 @@ OMEGA_BUCKET_FS_LEGACY = False
 OMEGA_USESSL = truefalse(os.environ.get('OMEGA_USESSL', False))
 #: additional kwargs for mongodb SSL connections
 OMEGA_MONGO_SSL_KWARGS = {
-    'ssl': OMEGA_USESSL,
+    'tls': OMEGA_USESSL,
     'tlsCAFile': os.environ.get('CA_CERTS_PATH') or None,
     'uuidRepresentation': 'standard',
     'authSource': 'admin',

--- a/omegaml/mongoshim.py
+++ b/omegaml/mongoshim.py
@@ -21,9 +21,14 @@ def sanitize_mongo_kwargs(kwargs):
     # -- if we receive "use_ssl" = False from cloud config but have
     #    a local CA defined, remove it. Otherwise mongo raises ConfigurationError
     kwargs = dict(kwargs)
-    if 'tlsCAFile' in kwargs and not kwargs.get('ssl'):
+    if 'ssl' in kwargs:
+        # ssl is alias to tls, should override tls (assume ssl is user-specified)
+        # see https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html
+        kwargs['tls'] = kwargs['ssl']
+        del kwargs['ssl']
+    if 'tlsCAFile' in kwargs and not kwargs.get('tls'):
         del kwargs['tlsCAFile']
-    if 'ssl_ca_certs' in kwargs and not kwargs.get('ssl'):
+    if 'ssl_ca_certs' in kwargs and not kwargs.get('tls'):
         del kwargs['ssl_ca_certs']
     return kwargs
 

--- a/omegaml/tests/features/util.py
+++ b/omegaml/tests/features/util.py
@@ -79,14 +79,14 @@ class Notebook:
         br.find_by_id('password_input').first.fill(self.password)
         br.click_link_by_id('login_submit')
         br.visit(jburl(br.url, self.user, nbstyle='tree'))
-        assert br.is_element_present_by_id('jupyter-main-app', wait_time=60)
+        assert br.is_element_present_by_id('ipython-main-app', wait_time=60)
         # check that there is actually a connection
         assert not br.is_text_present('Server error: Traceback', wait_time=15)
         assert not br.is_text_present('Connection refuse', wait_time=15)
 
     def login_nb(self):
         br = self.browser
-        assert br.is_element_present_by_id('jupyter-main-app', wait_time=10)
+        assert br.is_element_present_by_id('ipython-main-app', wait_time=10)
         br.find_by_id('password_input').fill(self.password)
         br.find_by_id('login_submit').click()
         br.visit(jburl(br.url, '', nbstyle='tree'))

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@ billiard==3.5.0.5
 bleach==3.1.0
 bokeh==1.2.0
 callable-pip==1.0.0
-celery==4.2.1
+celery<5
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dashserve_deps = ['dashserve']
 sql_deps = ['sqlalchemy', 'ipython-sql']
 snowflake_deps = ['snowflake-sqlalchemy==1.2.3']
 iotools_deps = ['boto>=2.49.0']
-streaming_deps = ['minibatch[all]>0.4.0']
+streaming_deps = ['minibatch[all]>=0.4.1']
 jupyter_deps = ['jupyterlab', 'jupyterhub==2.2.1']
 mlflow_deps = ['mlflow~=1.21.0']
 dev_deps = ['nose', 'twine', 'flake8', 'mock', 'behave', 'splinter', 'ipdb', 'bumpversion']
@@ -79,7 +79,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
     ],
     install_requires=[
-        'celery<5.0',
+        'celery>4.4,<5.0',
         'joblib>=0.9.4',
         'jupyter-client>=4.1.1',
         'mongoengine~=0.24.1',
@@ -113,7 +113,7 @@ setup(
         'tabulate>=0.8.2',  # required in cli
         'smart_open', # required in cli
         'imageio>=2.3.0', # require to store images
-        'psutil>=5.8' # required for profiling tracker
+        'psutil>=5.8', # required for profiling tracker
         'cachetools>=5.0.0' # required for session caching
     ],
     extras_require={


### PR DESCRIPTION
- mongoshim, defaults: pymongo prefers tls= instead of ssl=
- fastinsert: increase chunksize to increase insert throughput of
smaller dataframes
- pickable mongo collection: support authSource'd credentials
- fix celery dependency