### PR TITLE
runtime.scripts/tasks uses delegate pattern to call the backend

### DIFF
--- a/omegaml/backends/mlflow/gitprojects.py
+++ b/omegaml/backends/mlflow/gitprojects.py
@@ -2,9 +2,10 @@ import re
 
 from omegaml.backends.basedata import BaseDataBackend
 from omegaml.backends.mlflow.localprojects import MLFlowProject
+from omegaml.backends.package.packager import RunnablePackageMixin
 
 
-class MLFlowGitProjectBackend(BaseDataBackend):
+class MLFlowGitProjectBackend(RunnablePackageMixin, BaseDataBackend):
     """
     Backend to support git-sourced MLFlow projects
 

--- a/omegaml/backends/mlflow/localprojects.py
+++ b/omegaml/backends/mlflow/localprojects.py
@@ -6,9 +6,10 @@ from shutil import make_archive, unpack_archive
 from subprocess import run
 
 from omegaml.backends.basedata import BaseDataBackend
+from omegaml.backends.package.packager import RunnablePackageMixin
 
 
-class MLFlowProjectBackend(BaseDataBackend):
+class MLFlowProjectBackend(RunnablePackageMixin, BaseDataBackend):
     """
     Backend to support storage of MLFlow projects
 

--- a/omegaml/backends/package/localpip.py
+++ b/omegaml/backends/package/localpip.py
@@ -3,10 +3,10 @@ from os.path import basename, dirname
 import os
 
 from omegaml.backends.basedata import BaseDataBackend
-from omegaml.backends.package.packager import build_sdist, install_and_import, load_from_path
+from omegaml.backends.package.packager import build_sdist, install_and_import, load_from_path, RunnablePackageMixin
 
 
-class PythonPackageData(BaseDataBackend):
+class PythonPackageData(RunnablePackageMixin, BaseDataBackend):
     """
     Backend to support locally sourced custom scripts deployment to runtimes cluster
 

--- a/omegaml/backends/package/packager.py
+++ b/omegaml/backends/package/packager.py
@@ -9,13 +9,14 @@ sync_lock = threading.Lock()
 
 logger = logging.getLogger(__name__)
 
+
 def build_sdist(src, distdir):
     from distutils.core import run_setup
     # save argv. distutils run_setup changes argv and fails at restoring properly
     save_argv = list(sys.argv)
     # block any other thread from executing since we're changing cwd and sys.argv
     with sync_lock, tee.StdoutTee('build_sdist.out', 'w', 2), \
-         tee.StderrTee('build_sdist.err', 'w', 2):
+          tee.StderrTee('build_sdist.err', 'w', 2):
         # make sure no other processing is executing while we change the working directory for setup.py
         cwd = os.getcwd()
         sys.stdout.errors = None
@@ -32,7 +33,7 @@ def build_sdist(src, distdir):
             # restore cwd
             os.chdir(cwd)
             # restore sys argv
-            for i ,v in enumerate(save_argv):
+            for i, v in enumerate(save_argv):
                 sys.argv[i] = v
             if len(sys.argv) > len(save_argv):
                 del sys.argv[len(save_argv):]
@@ -74,6 +75,13 @@ def install_and_import(pkgfilename, package, installdir, keep=False):
     install_package(pkgfilename, installdir)
     mod = load_from_path(package, installdir, keep=keep)
     return mod
+
+
+class RunnablePackageMixin:
+    # mixin to Package backends to enable backend.perform('run') from tasks
+    def run(self, name, *args, keep=False, om=None, **kwargs):
+        mod = self.get(name, keep=keep)
+        return mod.run(om, *args, **kwargs)
 
 
 if __name__ == '__main__':

--- a/omegaml/backends/package/remotepip.py
+++ b/omegaml/backends/package/remotepip.py
@@ -4,10 +4,10 @@ import os
 import re
 
 from omegaml.backends.basedata import BaseDataBackend
-from omegaml.backends.package.packager import install_and_import
+from omegaml.backends.package.packager import install_and_import, RunnablePackageMixin
 
 
-class PythonPipSourcedPackageData(BaseDataBackend):
+class PythonPipSourcedPackageData(RunnablePackageMixin, BaseDataBackend):
     """
     Backend to support locally sourced custom scripts deployment to runtimes cluster
 
@@ -95,6 +95,7 @@ class PythonPipSourcedPackageData(BaseDataBackend):
         pip_name = pip_source.replace('pypi://', '')
         mod = install_and_import(pip_name, pkgname, dstdir, keep=keep)
         return mod
+
 
     @property
     def packages_path(self):

--- a/omegaml/backends/restapi/script.py
+++ b/omegaml/backends/restapi/script.py
@@ -18,7 +18,7 @@ class GenericScriptResource(object):
         """
         om = self.om
         payload = {} if payload is None else payload
-        promise = om.runtime.script(script_id).run(__format='python', **query, **payload)
+        promise = om.runtime.script(script_id).run(payload, __format='python', **query)
         result = self.prepare_result_from_run(promise.get(), script_id=script_id) if not self.is_async else promise
         return result
 

--- a/omegaml/example/demo/helloworld/helloworld/__init__.py
+++ b/omegaml/example/demo/helloworld/helloworld/__init__.py
@@ -2,7 +2,7 @@ def hello(**kwargs):
     return "hello from helloworld", kwargs
 
 
-def run(om, **kwargs):
+def run(om, *args, **kwargs):
     """
     the script API execution entry point
     :return: result

--- a/omegaml/runtimes/scriptproxy.py
+++ b/omegaml/runtimes/scriptproxy.py
@@ -23,7 +23,7 @@ class OmegaScriptProxy(object):
         self.scriptname = scriptname
         self.runtime = runtime
 
-    def run(self, as_callback=False, **kwargs):
+    def run(self, *args, as_callback=False, **kwargs):
         """
         run the script
 
@@ -40,7 +40,7 @@ class OmegaScriptProxy(object):
             AsyncResult
         """
         script_run = self.task(as_callback=as_callback)
-        return script_run.delay(self.scriptname, **kwargs)
+        return script_run.delay(self.scriptname, *args, **kwargs)
 
     def task(self, as_callback=False):
         task_name = 'run_omega_callback_script' if as_callback else 'run_omega_script'

--- a/omegaml/tests/core/test_package.py
+++ b/omegaml/tests/core/test_package.py
@@ -111,7 +111,7 @@ class PythonLocalPackageDataTests(TestCase):
         pkgsrc = 'pkg://{}'.format(pkgpath)
         om.scripts.put(pkgsrc, 'helloworld')
         print("***omega test_runtime (om, om.runtime)", om, om.runtime)
-        result = om.runtime.script('helloworld').run(text='foo')
+        result = om.runtime.script('helloworld').run({'foo': 'bar'}, text='foo')
         data = json.loads(result.get())
         self.assertIn('runtimes', data)
         expected = ['hello from helloworld', {'text': 'foo', 'pure_python': False}]


### PR DESCRIPTION
- matches how scripts are called to how model actions are called
- enables easier reuse and extension
- enables virtual functions to be saved to and run in om.scripts
- rename package.tasks.NotebookTask to ScriptTask
- fix on_success/on_retry/on_failure handler signature (#239)
- closes #238