### PR TITLE
add pre-/post task hooks using common .perform() backend method

### DIFF
--- a/omegaml/__init__.py
+++ b/omegaml/__init__.py
@@ -1,8 +1,6 @@
 import cachetools
-import logging
 
 from omegaml import defaults as _base_config
-
 from omegaml._version import version
 from omegaml.omega import OmegaDeferredInstance
 from omegaml.util import load_class, settings, base_loader

--- a/omegaml/backends/basemodel.py
+++ b/omegaml/backends/basemodel.py
@@ -63,6 +63,11 @@ class BaseModelBackend(BackendBaseCommon):
         """
         return False
 
+    @property
+    def _call_handler(self):
+        # the model store handles _pre and _post methods in self.perform()
+        return self.model_store
+
     def get(self, name, **kwargs):
         """
         retrieve a model

--- a/omegaml/backends/package/__init__.py
+++ b/omegaml/backends/package/__init__.py
@@ -1,2 +1,3 @@
 from .localpip import PythonPackageData
 from .remotepip import PythonPipSourcedPackageData
+

--- a/omegaml/backends/package/tasks.py
+++ b/omegaml/backends/package/tasks.py
@@ -73,10 +73,13 @@ def run_omega_script(self, scriptname, *args, **kwargs):
     dtstart = datetime.datetime.now()
     try:
         result = (self.get_delegate(scriptname, kind='scripts', pass_as='data_store')
-                  .run(scriptname, *self.delegate_args[1:], om=self.om, **self.delegate_kwargs))
+                  .perform('run', scriptname, *self.delegate_args[1:], om=self.om, **self.delegate_kwargs))
     except Exception as e:
         import traceback
-        result = "".join(traceback.TracebackException.from_exception(e).format())
+        if kwargs.get('__traceback') or self.logging[-1].lower() == 'debug':
+            result = "".join(traceback.TracebackException.from_exception(e).format())
+        else:
+            result = repr(e)
         exception = True
     else:
         exception = False

--- a/omegaml/tasks.py
+++ b/omegaml/tasks.py
@@ -25,65 +25,64 @@ if os.path.basename(sys.argv[0]) == 'celery':
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_predict(self, modelname, Xname, rName=None, pure_python=True, **kwargs):
-    result = self.get_delegate(modelname).predict(*self.delegate_args, **self.delegate_kwargs)
+    result = self.get_delegate(modelname).perform('predict', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_reduce(self, results, modelName=None, rName=None, pure_python=True, **kwargs):
-    result = self.get_delegate(modelName).reduce(modelName, results, **self.delegate_kwargs)
+    result = self.get_delegate(modelName).perform('reduce', modelName, results, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
-def omega_predict_proba(self, modelname, Xname, rName=None, pure_python=True,
-                        **kwargs):
-    result = self.get_delegate(modelname).predict_proba(*self.delegate_args, **self.delegate_kwargs)
+def omega_predict_proba(self, modelname, Xname, rName=None, pure_python=True, **kwargs):
+    result = self.get_delegate(modelname).perform('predict_proba', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_fit(self, modelname, Xname, Yname=None, pure_python=True, **kwargs):
-    result = self.get_delegate(modelname).fit(*self.delegate_args, **self.delegate_kwargs)
+    result = self.get_delegate(modelname).perform('fit', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_partial_fit(self,
                       modelname, Xname, Yname=None, pure_python=True, **kwargs):
-    result = self.get_delegate(modelname).partial_fit(*self.delegate_args, **self.delegate_kwargs)
+    result = self.get_delegate(modelname).perform('partial_fit', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_score(self, modelname, Xname, Yname=None, rName=True, pure_python=True,
                 **kwargs):
-    result = self.get_delegate(modelname).score(*self.delegate_args, **self.delegate_kwargs)
+    result = self.get_delegate(modelname).perform('score', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_fit_transform(self, modelname, Xname, Yname=None, rName=None,
                         pure_python=True, **kwargs):
-    result = self.get_delegate(modelname).fit_transform(*self.delegate_args, **self.delegate_kwargs)
+    result = self.get_delegate(modelname).perform('fit_transform', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_transform(self, modelname, Xname, rName=None, **kwargs):
-    result = self.get_delegate(modelname).transform(*self.delegate_args, **self.delegate_kwargs)
+    result = self.get_delegate(modelname).perform('transform', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
 def omega_decision_function(self, modelname, Xname, rName=None, **kwargs):
-    result = self.get_delegate(modelname).decision_function(*self.delegate_args, **self.delegate_kwargs)
+    result = self.get_delegate(modelname).perform('decision_function', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
 @shared_task(base=OmegamlTask, bind=True)
-def omega_gridsearch(self, modelname, Xname, Yname, parameters=None, **kwargs):
-    result = self.get_delegate(modelname).gridsearch(*self.delegate_args, **self.delegate_kwargs)
+def omega_gridsearch(self, modelname, Xname, Yname=None, parameters=None, **kwargs):
+    result = self.get_delegate(modelname).perform('gridsearch', *self.delegate_args, **self.delegate_kwargs)
     return sanitized(result)
 
 
@@ -126,6 +125,7 @@ def omega_ping(task, *args, logging=False, **kwargs):
         package_logger.log(pylevel, f'package log: running ping task {data}')
         print(f"print log: running ping task {data}")
     return data
+
 
 @worker_process_init.connect
 def fix_multiprocessing(**kwargs):


### PR DESCRIPTION
- backend.perform('method') calls backend.method() wrapped by
pre_/post_method calls to allow custom processing by mixins
- backends can override _call_handler to delegate processing
- prepares for openapi signature checks, data mapping