### PR TITLE
log exceptions in runtime tasks

### DIFF
--- a/omegaml/celery_util.py
+++ b/omegaml/celery_util.py
@@ -179,6 +179,14 @@ class OmegamlTask(EagerSerializationTaskMixin, Task):
                 logger = None
             try:
                 yield
+            except Exception as e:
+                # in case of DEBUG logging enabled, output exception
+                if logger and logger.isEnabledFor(logging.ERROR):
+                    import traceback
+                    tb = traceback.format_exc() if logger.isEnabledFor(logging.DEBUG) else ''
+                    msg = f'{e}\n{tb}'
+                    logger.error(msg)
+                raise
             finally:
                 if logger:
                     handler.flush()

--- a/omegaml/tasks.py
+++ b/omegaml/tasks.py
@@ -96,7 +96,7 @@ def omega_settings(self, *args, **kwargs):
 
 
 @shared_task(base=OmegamlTask, bind=True)
-def omega_ping(task, *args, logging=False, **kwargs):
+def omega_ping(task, *args, exception=False, **kwargs):
     import socket
     hostname = task.request.hostname or socket.gethostname()
     # resolve standard kwargs
@@ -112,6 +112,8 @@ def omega_ping(task, *args, logging=False, **kwargs):
         'kwargs': kwargs,
         'worker': hostname,
     }
+    if exception:
+        raise RuntimeError("intentional exception caused by exception=True kwarg")
     logname, level = task.logging
     if logname:
         import logging as logmod


### PR DESCRIPTION
- om.runtime.mode(logging=True) now logs exceptions, as is commonly expected
- om.runtime.model(logging='DEBUG') logs exception with traceback