### PR TITLE
improve runtime require() semantics

### DIFF
--- a/omegaml/runtimes/proxies/baseproxy.py
+++ b/omegaml/runtimes/proxies/baseproxy.py
@@ -44,7 +44,7 @@ class RuntimeProxyBase:
             require_kwargs.update({
                 'task': dict(__experiment=meta.attributes['tracking'].get('default'))
             })
-        self.runtime.require(**require_kwargs) if require_kwargs else None
+        self.runtime.require(**require_kwargs, override=False) if require_kwargs else None
 
     def require(self, label=None, always=False, drop=False, **kwargs):
         """

--- a/omegaml/runtimes/proxies/jobproxy.py
+++ b/omegaml/runtimes/proxies/jobproxy.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import logging
 
 from omegaml.runtimes.proxies.baseproxy import RuntimeProxyBase
-from omegaml.util import extend_instance
 
 logger = logging.getLogger(__file__)
 

--- a/omegaml/tests/core/test_runtime.py
+++ b/omegaml/tests/core/test_runtime.py
@@ -711,7 +711,16 @@ class RuntimeTests(OmegaTestMixin, TestCase):
         self.assertIsInstance(meta, om.models._Metadata)
         task = om.runtime.model('regmodel').task('omegaml.tasks.omega_fit')
         self.assertEqual(task.kwargs['routing']['label'], 'foo')
-        # -- test the permanent requirement is kept, despite runtime settings
-        om.runtime.require('baz')
+        # -- test the permanent requirement is kept even if runtime is reset
+        om = Omega()
         task = om.runtime.model('regmodel').task('omegaml.tasks.omega_fit')
         self.assertEqual(task.kwargs['routing']['label'], 'foo')
+        # -- test runtime requirement takes precedence
+        om.runtime.require('baz')
+        task = om.runtime.model('regmodel').task('omegaml.tasks.omega_fit')
+        self.assertEqual(task.kwargs['routing']['label'], 'baz')
+        # -- test we can reset a previous local require
+        om.runtime.require()
+        task = om.runtime.model('regmodel').task('omegaml.tasks.omega_fit')
+        self.assertEqual(task.kwargs['routing']['label'], 'foo')
+


### PR DESCRIPTION
- locally set require() precedes model attributes, for clarity
- model attributes require kwargs override default runtime