### PR TITLE
improve virtualobj storing

### DIFF
--- a/omegaml/backends/virtualobj.py
+++ b/omegaml/backends/virtualobj.py
@@ -1,6 +1,8 @@
-import sys
-
+import builtins
 import dill
+import sys
+import types
+import warnings
 
 from omegaml.backends.basedata import BaseDataBackend
 
@@ -87,13 +89,16 @@ class VirtualObjectBackend(BaseDataBackend):
         # the model store handles _pre and _post methods in self.perform()
         return self.model_store
 
-    def put(self, obj, name, attributes=None, **kwargs):
+    def put(self, obj, name, attributes=None, dill_kwargs=None, as_source=False, **kwargs):
         # TODO add obj signing so that only trustworthy sources can put functions
-        # ensure we have a dill'able object
-        # -- only instances can be dill'ed
-        if isinstance(obj, type):
-            obj = obj()
-        data = dill.dumps(obj)
+        # since 0.15.6: only __main__ objects are stored as bytecodes,
+        #               all module code is stored as source code. This
+        #               removes the dependency on opcode parity between client
+        #               and server. Source objects are compiled into __main__
+        #               within the runtime. This is a tradeoff compatibility
+        #               v.s. execution time. Use as_source=False to force
+        #               storing bytecodes.
+        data = dilldip.dumps(obj, as_source=as_source, **(dill_kwargs or {}))
         filename = self.model_store.object_store_key(name, '.dill', hashed=True)
         gridfile = self._store_to_file(self.model_store, data, filename)
         return self.model_store._make_metadata(
@@ -107,27 +112,19 @@ class VirtualObjectBackend(BaseDataBackend):
     def get(self, name, version=-1, force_python=False, lazy=False, **kwargs):
         meta = self.model_store.metadata(name)
         outf = meta.gridfile
-        # compat: Python 3.8.x < 3.8.2
-        # https://github.com/python/cpython/commit/b19f7ecfa3adc6ba1544225317b9473649815b38
-        # https://docs.python.org/3.8/whatsnew/changelog.html#python-3-8-2-final
-        try:
-            data = outf.read()
-            obj = dill.loads(data)
-        except ModuleNotFoundError as e:
-            # if the functions original module is not known, simulate it
-            # this is to deal with functions created outside of __main__
-            # see https://stackoverflow.com/q/26193102/890242
-            #     https://stackoverflow.com/a/70513630/890242
-            sys.modules[e.name] = sys.modules['__main__']
-            obj = dill.loads(data)
-
+        data = outf.read()
+        obj = dilldip.loads(data)
         outf.close()
         return obj
+
+    def _ensure_handler_instance(self, obj):
+        # ensure VirtualObjectHandler classes are transformed to a virtualobj
+        return obj() if isinstance(obj, type) and issubclass(obj, VirtualObjectHandler) else obj
 
     def predict(self, modelname, xName, rName=None, **kwargs):
         # make this work as a model backend too
         meta = self.model_store.metadata(modelname)
-        handler = self.get(modelname)
+        handler = self._ensure_handler_instance(self.get(modelname))
         X = self.data_store.get(xName)
         return handler(method='predict', data=X, meta=meta, store=self.model_store, rName=rName,
                        tracking=self.tracking, **kwargs)
@@ -135,7 +132,7 @@ class VirtualObjectBackend(BaseDataBackend):
     def run(self, scriptname, *args, **kwargs):
         # run as a script
         meta = self.model_store.metadata(scriptname)
-        handler = self.get(scriptname)
+        handler = self._ensure_handler_instance(self.get(scriptname))
         data = args[0] if args else None
         kwargs['args'] = args
         return handler(method='run', data=data, meta=meta, store=self.data_store, tracking=self.tracking, **kwargs)
@@ -159,7 +156,7 @@ class VirtualObjectBackend(BaseDataBackend):
             om.runtime.mapreduce
         """
         meta = self.model_store.metadata(modelname)
-        handler = self.get(modelname)
+        handler = self._ensure_handler_instance(self.get(modelname))
         return handler(method='reduce', data=results, meta=meta, store=self.model_store, rName=rName,
                        tracking=self.tracking, **kwargs)
 
@@ -221,3 +218,138 @@ class VirtualObjectHandler(object):
         }
         methodfn = MAP[method]
         return methodfn(data=data, meta=meta, store=store, tracking=tracking, **kwargs)
+
+
+class _DillDip:
+    # magic id for dipped dill objects
+    # -- why 0x1565? 15g of dill dip have 65 kcal
+    # -- see https://www.nutritionvalue.org/Dill_dip%2C_regular_12350210_nutritional_value.html
+    # -- also 42 is overused
+    __calories = 0x1565
+
+    # enhanced dill for functions and classes
+    # - warns about bound variables that could cause issues when undilling
+    # - checks types and functions are defined in __main__ before dilling (so we will code, not references),
+    #   dynamically recompiles in __main__ before dilling if source is available
+    # - saves source code for improved python cross-version compatibility
+    # - falls back on standard dill for any other object type
+    def dumps(self, obj, as_source=False, **dill_kwargs):
+        # enhanced flavor of dill that stores source code for cross-version compatibility
+        # ensure we have a dill'able object
+        # if isinstance(obj, type):
+        #    obj = obj()
+        self._check(obj)
+        data = (self._dill_main(obj, **dill_kwargs) or
+                self._dill_types_or_function(obj, as_source=as_source, **dill_kwargs) or
+                self._dill_dill(obj, **dill_kwargs))
+        return data
+
+    def loads(self, data):
+        # compat: Python 3.8.x < 3.8.2
+        # https://github.com/python/cpython/commit/b19f7ecfa3adc6ba1544225317b9473649815b38
+        # https://docs.python.org/3.8/whatsnew/changelog.html#python-3-8-2-final
+        try:
+            obj = self._dynamic_compile(dill.loads(data), module='__main__')
+        except ModuleNotFoundError as e:
+            # if the functions original module is not known, simulate it
+            # this is to deal with functions created outside of __main__
+            # see https://stackoverflow.com/q/26193102/890242
+            #     https://stackoverflow.com/a/70513630/890242
+            mod = types.ModuleType(e.name, 'dynamic module')
+            sys.modules[e.name] = mod  # sys.modules['__main__']
+            obj = dill.loads(data)
+        return obj
+
+    def _check(self, obj):
+        # check for freevars
+        freevars = dill.detect.nestedglobals(obj)
+        freevars += list(dill.detect.freevars(obj).keys())
+        freevars += list(dill.detect.referredglobals(obj))
+        freevars = [n for n in set(freevars) if n not in dir(builtins)]
+        if len(freevars):
+            warnings.warn(
+                f'The {repr(obj)} module references {freevars}, this may lead to errors at runtime; import/declare all variables within method/function scope')
+
+    def _dill_dill(self, obj, **dill_kwargs):
+        # fallback to standard dill
+        # e.g. class instances cannot be dumped unless they come from __main__
+        return dill.dumps(obj, **dill_kwargs)
+
+    def _dill_main(self, obj, **dill_kwargs):
+        # dynamic __main__ objects can be dilled directly, there is no source code
+        if dill.source.isfrommain(obj) or dill.source.isdynamic(obj):
+            return dill.dumps(obj, **dill_kwargs)
+        return None
+
+    def _dill_types_or_function(self, obj, as_source=False, **dill_kwargs):
+        # classes or functions should be dilled as source, unless they come from __main__
+        if isinstance(obj, type) or isinstance(obj, types.FunctionType):
+            return self._dill_source(obj, as_source=as_source, **dill_kwargs)
+        return None
+
+    def _dill_source(self, obj, as_source=False, **dill_kwargs):
+        # include source code along dill
+        try:
+            source = dill.source.getsource(obj, lstrip=True)
+            source_obj = {'__dipped__': self.__calories,
+                          'source': ''.join(source),
+                          'name': getattr(obj, '__name__'),
+                          '__dict__': getattr(obj, '__dict__', {})}
+        except:
+            source_obj = {}
+        else:
+            # check obvious references in source
+            if '__main__' in source_obj.get('source', []):
+                warnings.warn(f'The {repr(obj)} module references __main__, this may lead to unexpected results')
+        if as_source and source_obj:
+            # if source code was requested, transport as source code
+            data = dill.dumps(source_obj, **dill_kwargs)
+        elif source_obj and dill.detect.getmodule(obj) != '__main__':
+            # we have a source obj, make sure we can dill it and have source to revert from
+            # compile to __main__ module to enable full serialization
+            warnings.warn(f'The {repr(obj)} module is defined outside of __main__, recompiling in __main__.')
+            obj = self._dynamic_compile(source_obj, module='__main__')
+            source_obj['dill'] = dill.dumps(obj, **dill_kwargs)
+            data = dill.dumps(source_obj, **dill_kwargs)
+        else:
+            # we have no source object, revert to standard dill
+            if as_source:
+                warnings.warn(f'Cannot save {repr(obj)} as source code, reverting to dill')
+            # could not get source code, revert to dill
+            data = dill.dumps(obj, **dill_kwargs)
+        return data
+
+    def _dynamic_compile(self, obj, module='__main__'):
+        # re-compile source obj in __main__
+        if self.isdipped(obj):
+            if 'dill' in obj:
+                try:
+                    obj = dill.loads(obj['dill'])
+                except:
+                    warnings.warn('could not undill, reverting to dynamic compile source code')
+                else:
+                    return obj
+            source, data = obj.get('source'), obj.get('__dict__', {})
+            mod = types.ModuleType(module)
+            mod.__dict__.update({'__compiling__': True,
+                                 'virtualobj': virtualobj,
+                                 'VirtualObjectHandler': VirtualObjectHandler})
+            sys.modules[module] = mod
+            code = compile(source, '<string>', 'exec')
+            exec(code, mod.__dict__)
+            obj = getattr(mod, obj['name'])
+            # restore instance data, if any
+            try:
+                getattr(obj, '__dict__', {}).update(data)
+            except AttributeError:
+                # we ignore attribute errors on class types
+                if not isinstance(obj, type):
+                    warnings.warn(f'could not restore instance data for {obj}')
+        return obj
+
+    def isdipped(self, data_or_obj):
+        obj = dill.loads(data_or_obj) if not isinstance(data_or_obj, dict) else data_or_obj
+        return isinstance(obj, dict) and obj.get('__dipped__') == self.__calories
+
+
+dilldip = _DillDip()

--- a/omegaml/mixins/store/virtualobj.py
+++ b/omegaml/mixins/store/virtualobj.py
@@ -1,7 +1,7 @@
 import re
 
 
-from omegaml.backends.virtualobj import VirtualObjectBackend
+from omegaml.backends.virtualobj import VirtualObjectBackend, VirtualObjectHandler
 
 
 class VirtualObjectMixin(object):
@@ -20,8 +20,10 @@ class VirtualObjectMixin(object):
         return (self._vobj_meta is not None and
                 self._vobj_meta.kind == VirtualObjectBackend.KIND)
 
-    def _getvirtualobjfn(self, name):
-        virtualobjfn = super(VirtualObjectMixin, self).get(name)
+    def _getvirtualobjfn(self, name, **kwargs):
+        virtualobjfn = super(VirtualObjectMixin, self).get(name, **kwargs)
+        if isinstance(virtualobjfn, type):
+            virtualobjfn = virtualobjfn()
         return virtualobjfn
 
     def _resolve_realname(self, name, kwargs):

--- a/omegaml/tests/core/test_virtualobj.py
+++ b/omegaml/tests/core/test_virtualobj.py
@@ -138,6 +138,8 @@ class VirtualObjectTests(OmegaTestMixin, TestCase):
 
 @virtualobj
 def myvirtualfn(data=None, meta=None, method=None, store=None, **kwargs):
+    import datetime
+
     real_data_name = '{}_data'.format(meta.name)
     if method == 'get':
         data = store.get(real_data_name)
@@ -165,6 +167,7 @@ class MyVirtualObjectHandler(VirtualObjectHandler):
         return store.get(self.real_data_name(meta)) or 'no data yet'
 
     def put(self, data=None, meta=None, store=None, **kwargs):
+        import datetime
         entrymeta = store.put(data, self.real_data_name(meta), attributes={
             'virtualobj_ref': meta.name,
         })
@@ -178,9 +181,9 @@ class MyVirtualObjectHandler(VirtualObjectHandler):
         store.drop(self.real_data_name(meta), force=True)
         return 'ok, deleted'
 
-
 @virtualobj
 def myvirtualobjfn_with_basename(data=None, meta=None, method=None, base_name=None, store=None, **kwargs):
+    import datetime
     real_data_name = base_name
     if method == 'get':
         data = store.get(real_data_name)

--- a/omegaml/tests/tensorflow/test_tfestimator.py
+++ b/omegaml/tests/tensorflow/test_tfestimator.py
@@ -1,6 +1,7 @@
+from unittest import TestCase, skip
+
 import unittest
 from inspect import isfunction
-from unittest import TestCase, skip
 
 from omegaml import Omega
 from omegaml.backends.virtualobj import virtualobj
@@ -315,7 +316,6 @@ class TFEstimatorModelBackendTests(OmegaTestMixin, TestCase):
 
     def test_predict_from_objecthandler(self):
         import tensorflow as tf
-        from omegaml.backends.tensorflow import _tffn
         from omegaml.backends.tensorflow.tfestimatormodel import TFEstimatorModel
 
         om = self.om
@@ -323,6 +323,7 @@ class TFEstimatorModelBackendTests(OmegaTestMixin, TestCase):
         @virtualobj
         def train_xy_fn(Xname=None, Yname=None, **kwargs):
             import omegaml as om
+            from omegaml.backends.tensorflow import _tffn
             X = om.datasets.get(Xname)
             Y = om.datasets.get(Yname)
             dataset = _tffn('pandas_input_fn')(X, Y, shuffle=True)
@@ -331,6 +332,7 @@ class TFEstimatorModelBackendTests(OmegaTestMixin, TestCase):
         @virtualobj
         def test_x_fn(Xname=None, **kwargs):
             import omegaml as om
+            from omegaml.backends.tensorflow import _tffn
             X = om.datasets.get(Xname)
             dataset = _tffn('pandas_input_fn')(X, shuffle=False)
             return dataset


### PR DESCRIPTION
this improves portability for `@virtualobj` functions across python versions  

- store source code for functions, classes defined outside `__main__`
- issue a warning if a module is stored that has a `__main__` block