### PR TITLE
backport tarfile.extractall filter to Python < 3.12

### DIFF
--- a/omegaml/backends/mlflow/models.py
+++ b/omegaml/backends/mlflow/models.py
@@ -5,6 +5,7 @@ import os
 from tarfile import TarFile
 
 from omegaml.backends.basemodel import BaseModelBackend
+from omegaml.util import tarfile_safe_extractall
 
 
 class MLFlowModelBackend(BaseModelBackend):
@@ -118,7 +119,7 @@ class MLFlowModelBackend(BaseModelBackend):
         with open(tmpfn, 'wb') as fout:
             fout.write(infile.read())
         with TarFile(tmpfn, mode='r') as tarf:
-            tarf.extractall(model_path)
+            tarfile_safe_extractall(tarf, model_path, filter='data')
         for fn in glob.glob(f'{model_path}/**/MLmodel', recursive=True):
             model = mlflow.pyfunc.load_model(os.path.dirname(fn))
             break

--- a/omegaml/mixins/store/imexport.py
+++ b/omegaml/mixins/store/imexport.py
@@ -13,7 +13,7 @@ from omegaml.documents import Metadata
 from omegaml.mixins.store.promotion import PromotionMixin
 from omegaml.omega import Omega
 from omegaml.store import OmegaStore
-from omegaml.util import IterableJsonDump, load_class, SystemPosixPath
+from omegaml.util import IterableJsonDump, load_class, SystemPosixPath, tarfile_safe_extractall
 
 
 class ObjectImportExportMixin:
@@ -135,7 +135,7 @@ class OmegaExportArchive:
                 # SEC: CWE-22 avoid extracting vulnerable file paths
                 # - reason: files are extracted using Python's tarfile 'data' filter which fixes the issue
                 # - status: fixed
-                tar.extractall(target, filter='data')
+                tarfile_safe_extractall(tar, target, filter='data')
             # the first entry in the archive is the actual archive contents
             basename = list(target.iterdir())[0]
             arc = self.__class__(basename, self.store)


### PR DESCRIPTION
fixes failing builds on Python 3.10, 3.11
amends PR #374