### PR TITLE
Simplify revisions

### DIFF
--- a/omegaml/tests/core/test_imexport.py
+++ b/omegaml/tests/core/test_imexport.py
@@ -129,7 +129,8 @@ class ImportExportMixinTests(OmegaTestMixin, unittest.TestCase):
         self.assertEqual(om.models.list(hidden=True), ['mymodel'])
         self.assertNotIn('mymodel@version1', om.models.list())
         self.assertNotIn('mymodel@version2', om.models.list())
-        self.assertEqual(len(om.models.revisions('mymodel')), 2)
+        # -- expected @latest, @version1, @version2
+        self.assertEqual(len(om.models.revisions('mymodel')), 3)
         # check we can access the versioned model
         mdl = om.models.get('mymodel@version1')
         self.assertIsInstance(mdl, LinearRegression)
@@ -263,7 +264,8 @@ class ImportExportMixinTests(OmegaTestMixin, unittest.TestCase):
                                                    promote_to=om_restore)
             self.assertIn('mydf', om_restore.datasets.list())
             self.assertIn('mymodel', om_restore.models.list())
-            self.assertEqual(len(om_restore.models.revisions('mymodel')), 3)
+            # expected model versions @latest, @version1, @version2 + base version
+            self.assertEqual(len(om_restore.models.revisions('mymodel')), 4)
             # check model versions are as expected
             # -- latest
             mdl = om_restore.models.get('mymodel')
@@ -281,7 +283,8 @@ class ImportExportMixinTests(OmegaTestMixin, unittest.TestCase):
                                                    pattern='jobs/.*')
             self.assertEqual(om_restore.jobs.list(), ['myjob.ipynb'])
             # ensure models were not touched
-            self.assertEqual(len(om_restore.models.revisions('mymodel')), 3)
+            # -- expect @latest, @version1, @version2 + base version
+            self.assertEqual(len(om_restore.models.revisions('mymodel')), 4)
 
 
 if __name__ == '__main__':

--- a/omegaml/tests/core/test_modelversions.py
+++ b/omegaml/tests/core/test_modelversions.py
@@ -194,4 +194,19 @@ class ModelVersionMixinTests(OmegaTestMixin, TestCase):
         # without
         store.get('mymodel')
 
+    def test_revisions(self):
+        store = self.om.models
+        store.register_mixin(ModelVersionMixin)
+        clf = LinearRegression()
+        # no model, no revisions
+        revisions = store.revisions('regmodel')
+        self.assertIsNone(revisions)
+        # store model and check revisions
+        store.put(clf, 'regmodel', tag='version1')
+        store.put(clf, 'regmodel', tag='version2')
+        revisions = store.revisions('regmodel')
+        self.assertEqual(revisions, ['regmodel@latest', 'regmodel@version1', 'regmodel@version2'])
+        revisions = store.revisions('regmodel', raw=True)
+        self.assertIsInstance(revisions[-1], store._Metadata)
+
 


### PR DESCRIPTION
simplify model and dataset revisions
    
    - store.revisions() returns a list of names@tag
    - simplifies retrieval of revisions similarly to store.list()