### PR TITLE
Enable autotrack fit score

### DIFF
--- a/omegaml/backends/keras.py
+++ b/omegaml/backends/keras.py
@@ -71,7 +71,7 @@ class KerasBackend(BaseModelBackend):
 
     def predict(self, modelname, Xname, rName=None, pure_python=True, **kwargs):
         model = self.get_model(modelname)
-        X = self._resolve_input_data('predict', Xname, **kwargs)
+        X = self._resolve_input_data('predict', Xname, 'X', **kwargs)
         result = model.predict(X)
         return self._prepare_result('predict', result, rName=rName, pure_python=pure_python, **kwargs)
 

--- a/omegaml/backends/tracking/base.py
+++ b/omegaml/backends/tracking/base.py
@@ -31,12 +31,13 @@ class TrackingProvider:
            for an example.
     """
 
-    def __init__(self, experiment, store=None, model_store=None):
+    def __init__(self, experiment, store=None, model_store=None, autotrack=False):
         self._experiment = experiment
         self._run = None
         self._store = store
         self._model_store = model_store
         self._extra_log = None
+        self._autotrack = autotrack
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self._experiment})"
@@ -45,6 +46,14 @@ class TrackingProvider:
     def userid(self):
         defaults = getattr(self._store, 'defaults', None) or settings()
         return getattr(defaults, 'OMEGA_USERID', getpass.getuser())
+
+    @property
+    def autotrack(self):
+        return self._autotrack
+
+    @autotrack.setter
+    def autotrack(self, value):
+        self._autotrack = value
 
     def experiment(self, name=None):
         self._experiment = name or self._experiment
@@ -127,7 +136,10 @@ class TrackingProvider:
         from omegaml.backends.tracking import TensorflowCallback
         return TensorflowCallback(self)
 
-    def data(self, experiment=None, run=None, event=None, step=None, key=None, raw=False):
+    def data(self, experiment=None, run=None, event=None, step=None, key=None, raw=False, **query):
+        raise NotImplementedError
+
+    def clear(self, force=False):
         raise NotImplementedError
 
     def flush(self):

--- a/omegaml/runtimes/proxies/modelproxy.py
+++ b/omegaml/runtimes/proxies/modelproxy.py
@@ -56,7 +56,7 @@ class OmegaModelProxy(RuntimeProxyBase):
         """
         return self.runtime.task(name)
 
-    def experiment(self, experiment=None, label=None, provider=None):
+    def experiment(self, experiment=None, label=None, provider=None, **tracker_kwargs):
         """ return the experiment for this model
 
         If an experiment does not exist yet, it will be created. The
@@ -69,6 +69,7 @@ class OmegaModelProxy(RuntimeProxyBase):
             experiment (str): the experiment name, defaults to the modelname
             label (str): the runtime label, defaults to 'default'
             provider (str): the provider to use, defaults to 'default'
+            tracker_kwargs (dict): additional kwargs to pass to the tracker
 
         Returns:
             OmegaTrackingProxy() instance
@@ -78,7 +79,7 @@ class OmegaModelProxy(RuntimeProxyBase):
         exp = exps[0] if exps else None
         experiment = experiment or self.modelname
         if exp is None:
-            exp = self.runtime.experiment(experiment, provider=provider)
+            exp = self.runtime.experiment(experiment, provider=provider, **tracker_kwargs)
             if not label in self.experiments():
                 exp.track(self.modelname, label=label)
         return exp

--- a/omegaml/runtimes/proxies/trackingproxy.py
+++ b/omegaml/runtimes/proxies/trackingproxy.py
@@ -30,12 +30,13 @@ class OmegaTrackingProxy(RuntimeProxyBase):
         * ExperimentBackend
     """
 
-    def __init__(self, experiment=None, provider=None, runtime=None, implied_run=True):
+    def __init__(self, experiment=None, provider=None, runtime=None, implied_run=True, **tracker_kwargs):
         self.provider = provider
         self._experiment = experiment
         self._implied_run = implied_run
         self._with_experiment = None
         self._tracker = None
+        self._tracker_kwargs = tracker_kwargs
         super().__init__(experiment, runtime=runtime)
 
 
@@ -69,7 +70,7 @@ class OmegaTrackingProxy(RuntimeProxyBase):
             om = self.runtime.omega
             fqdn = SystemPosixPath(ExperimentBackend.exp_prefix) / self._experiment
             exp = (om.models.get(str(fqdn), data_store=om.datasets) or
-                   self.create_experiment(self._experiment, provider=self.provider))
+                   self.create_experiment(self._experiment, provider=self.provider, **self._tracker_kwargs))
             self._tracker = exp
         return self._tracker
 

--- a/omegaml/runtimes/runtime.py
+++ b/omegaml/runtimes/runtime.py
@@ -308,19 +308,20 @@ class OmegaRuntime(object):
         self.require(**self._sanitize_require(require)) if require else None
         return OmegaScriptProxy(scriptname, runtime=self)
 
-    def experiment(self, experiment, provider=None, implied_run=True):
+    def experiment(self, experiment, provider=None, implied_run=True, **tracker_kwargs):
         """ set the tracking backend and experiment
 
         Args:
             experiment (str): the name of the experiment
             provider (str): the name of the provider
+            tracker_kwargs (dict): additional kwargs for the tracker
 
         Returns:
             OmegaTrackingProxy
         """
         from omegaml.runtimes.proxies.trackingproxy import OmegaTrackingProxy
         # tracker implied_run means we are using the currently active run, i.e. with block will call exp.start()
-        tracker = OmegaTrackingProxy(experiment, provider=provider, runtime=self, implied_run=implied_run)
+        tracker = OmegaTrackingProxy(experiment, provider=provider, runtime=self, implied_run=implied_run, **tracker_kwargs)
         return tracker
 
     def task(self, name, **kwargs):

--- a/omegaml/store/base.py
+++ b/omegaml/store/base.py
@@ -677,7 +677,7 @@ class OmegaStore(object):
             return backend.drop(name, force=force, version=version, **kwargs)
         return self._drop(name, force=force, version=version)
 
-    def _drop(self, name, force=False, version=-1):
+    def _drop(self, name, force=False, version=-1, **kwargs):
         meta = self.metadata(name, version=version)
         if meta is None and not force:
             raise DoesNotExist()

--- a/omegaml/store/queryops.py
+++ b/omegaml/store/queryops.py
@@ -413,11 +413,14 @@ def ensure_index_limit(idx, **kwargs):
     return idx, kwargs
 
 
-def sanitize_filter(filter, no_ops=False):
+def sanitize_filter(filter, no_ops=None):
     """ sanitize mongodb filter statements """
+    import __main__ as main # noqa
+    is_interactive = sys.flags.interactive or not hasattr(main, '__file__')
+    no_ops = no_ops if no_ops is not None else is_interactive
     injection_ops = ['$where', '$mapReduce']
     user_ops = [k for k in filter if k.strip().startswith('$') and k not in injection_ops]
-    ops_to_remove = user_ops + injection_ops if no_ops else injection_ops
+    ops_to_remove = user_ops + injection_ops if not no_ops else injection_ops
     # sanitize user and default operators
     if user_ops and not no_ops:
         warnings.warn(f'Your MongoDB query contains operators {user_ops} which may be unsafe if not sanitized.')

--- a/omegaml/tests/core/test_tracking.py
+++ b/omegaml/tests/core/test_tracking.py
@@ -31,6 +31,15 @@ class TrackingTestCases(OmegaTestMixin, unittest.TestCase):
         idxs_keys = [list(sorted(d.keys())) for d in idxs]
         self.assertTrue(any(keys == ['data.event', 'data.run'] for keys in idxs_keys))
 
+    def test_clear(self):
+        om = self.om
+        exp = om.runtime.experiment('test')
+        with exp:
+            exp.log_metric('accuracy', .98)
+        self.assertEqual(len(exp.data()), 3)
+        exp.clear(force=True)
+        self.assertIsNone(exp.data())
+
     def test_ensure_active(self):
         # explicit start
         om = self.om
@@ -176,7 +185,7 @@ class TrackingTestCases(OmegaTestMixin, unittest.TestCase):
         lr = LogisticRegression(solver='liblinear', multi_class='auto')
         lr.fit(X, Y)
         om.models.put(lr, 'mymodel')
-        tracker = om.runtime.experiment('expfoo')
+        tracker = om.runtime.experiment('expfoo', autotrack=True)
         tracker.track('mymodel')
         om.runtime.model('mymodel').score(X, Y)
         exp = tracker.experiment
@@ -199,7 +208,7 @@ class TrackingTestCases(OmegaTestMixin, unittest.TestCase):
         lr = LogisticRegression(solver='liblinear', multi_class='auto')
         lr.fit(X, Y)
         om.models.put(lr, 'mymodel')
-        tracker = om.runtime.experiment('expfoo')
+        tracker = om.runtime.experiment('expfoo', autotrack=True)
         tracker.track('mymodel')
         resp = om.runtime.model('mymodel').score(X, Y)
         exp = tracker.experiment


### PR DESCRIPTION
- enable tracking provider autotrack=True for runtime predict(), fit(), score()
- provider.clear() now resets an experiment (useful for testing)
- improve support for logging objects of new pandas data types