### PR TITLE
enhance input/output validation

### DIFF
--- a/omegaml/backends/restapi/service.py
+++ b/omegaml/backends/restapi/service.py
@@ -43,7 +43,7 @@ class GenericServiceResource:
         self.om.models.validate(model_id, X=payload)
         promise = self.om.runtime.model(model_id).predict(payload, **query)
         result = self.prepare_result(promise.get(), model_id=model_id) if not self.is_async else promise
-        self.om.models.validate(model_id, Y=result)
+        self.om.models.validate(model_id, Y=result, result=result)
         return result
 
     def predict_proba(self, model_id, query, payload):
@@ -95,7 +95,12 @@ class GenericServiceResource:
         else:
             data = result
         # ensure response is json serializable
-        if not isinstance(data, (list, dict, tuple)):
+        # -- json-serializable data is returned as is
+        # -- exceptions are raised as is
+        # -- all other data is wrapped in a dict
+        if isinstance(data, Exception):
+            raise data
+        elif not isinstance(data, (list, dict, tuple)):
             data = {'data': data}
         return data
 

--- a/omegaml/backends/sqlalchemy.py
+++ b/omegaml/backends/sqlalchemy.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import StatementError
 from urllib.parse import quote_plus
 
 from omegaml.backends.basedata import BaseDataBackend
-from omegaml.util import ProcessLocal, KeepMissing, tqdm_if_interactive
+from omegaml.util import ProcessLocal, KeepMissing, tqdm_if_interactive, signature
 
 try:
     import snowflake
@@ -176,10 +176,7 @@ class SQLAlchemyBackend(BaseDataBackend):
         return super().drop(name, **kwargs)
 
     def sign(self, values):
-        # sign a set of values
-        # -- this is used to ensure the values are not tampered with
-        # -- when passed to a SQL query
-        return sha256((str(threading.get_ident()) + str(values)).encode('utf-8')).hexdigest()
+        return signature(values)
 
     def get(self, name, sql=None, chunksize=None, raw=False, sqlvars=None,
             secrets=None, index=True, keep=None, lazy=False, table=None, trusted=False, *args, **kwargs):

--- a/omegaml/client/userconf.py
+++ b/omegaml/client/userconf.py
@@ -17,7 +17,10 @@ def ensure_api_url(api_url, defaults, key=default_key, fallback=fallback_url):
     api_url_default = os.environ.get(key) or os.environ.get(default_key) or fallback
     api_url = api_url or getattr(defaults, key, getattr(defaults, default_key, api_url_default))
     allow_test_local = _base_config.is_test_run and not api_url.startswith('http')
-    valid_url = sec_validate_url(api_url) if not allow_test_local else api_url == 'local'
+    # SEC: ensure we only allow local urls in test mode, all else must be valid urls
+    if allow_test_local and api_url in ('local', ''):
+        return api_url
+    valid_url = sec_validate_url(api_url)
     assert valid_url, f"expected a valid url, got {api_url}"
     return api_url
 

--- a/omegaml/mixins/store/extdmeta.py
+++ b/omegaml/mixins/store/extdmeta.py
@@ -219,7 +219,11 @@ class SignatureMixin:
     def validate(self, name, X=None, Y=None, result=None, error=None, **kwargs):
         meta = self.metadata(name, **kwargs)
         signature = meta.attributes.get('signature')
+
         def _do_validate(k, v):
+            vv = v.get('data') if isinstance(v, dict) else None
+            v = vv if isinstance(vv, Exception) else v
+            status_code = None
             if isinstance(v, Exception) or k == 'error':
                 status_code = v.args[-1] if len(v.args) > 0 else 400
                 schema = (signature.get('errors') or {}).get(str(status_code), {}).get('schema')

--- a/omegaml/mixins/store/modelversion.py
+++ b/omegaml/mixins/store/modelversion.py
@@ -141,7 +141,7 @@ class ModelVersionMixin(object):
         if '^' in str(name):
             version = -1 * (name.count('^') + 1)
             name = name.split('^')[0].split('@')[0]
-        elif '@' in name:
+        elif '@' in str(name):
             name, tag = name.split('@')
         return name, tag, version
 

--- a/omegaml/runtimes/proxies/baseproxy.py
+++ b/omegaml/runtimes/proxies/baseproxy.py
@@ -34,7 +34,7 @@ class RuntimeProxyBase:
 
     def _apply_require(self):
         self.meta = meta = self.store.metadata(self.name)
-        assert meta is not None, f"{self.store.prefix}/{self.name} does not exist".format(**locals())
+        assert meta is not None, f"{self.store.prefix}{self.name} does not exist".format(**locals())
         # get common require kwargs
         require_kwargs = meta.attributes.get('require', {})
         # enable default tracking, unless explicitly tracked

--- a/omegaml/runtimes/runtime.py
+++ b/omegaml/runtimes/runtime.py
@@ -244,8 +244,9 @@ class OmegaRuntime(object):
                                **self._require_kwargs['task'])
                 ex_routing = dict(**self._task_default_kwargs['routing'],
                                   **self._require_kwargs['routing'])
-                task = {k: v for k, v in task.items() if k not in ex_task}
-                routing = {k: v for k, v in routing.items() if k not in ex_routing}
+                exists_or_none = lambda k, d: k not in d or d.get(k, False) is None
+                task = {k: v for k, v in task.items() if exists_or_none(k, ex_task)}
+                routing = {k: v for k, v in routing.items() if exists_or_none(k, ex_routing)}
             if always:
                 self._task_default_kwargs['routing'].update(routing)
                 self._task_default_kwargs['task'].update(task)

--- a/omegaml/store/query.py
+++ b/omegaml/store/query.py
@@ -44,8 +44,8 @@ class MongoQ(object):
     2. return the dataframe
 
     """
-    def __init__(self, **kwargs):
-        self.conditions = self._sanitize_filter(kwargs)
+    def __init__(self, _trusted=False, **kwargs):
+        self.conditions = self._sanitize_filter(kwargs, trusted=_trusted)
         self.qlist = [('', self)]
         # should we return ~(conditions)
         self._inv = False
@@ -233,9 +233,9 @@ class MongoQ(object):
         notq = copy.deepcopy(self).negate()
         return notq
 
-    def _sanitize_filter(self, filter):
+    def _sanitize_filter(self, filter, trusted=False):
         from omegaml.store.queryops import sanitize_filter
-        return sanitize_filter(filter)
+        return sanitize_filter(filter, trusted=trusted)
 
 
 
@@ -266,7 +266,7 @@ class Filter(object):
     """
     _debug = False
 
-    def __init__(self, coll, __query=None, **kwargs):
+    def __init__(self, coll, __query=None, _trusted=False, **kwargs):
         """
         Filter objects use MongoQ query expression to build
         complex filters.
@@ -291,9 +291,9 @@ class Filter(object):
         self.coll = coll
         self.trace = False
         self.exc = None
-        self.q = self.build_query(__query, **kwargs)
+        self.q = self.build_query(__query, _trusted=_trusted, **kwargs)
 
-    def build_query(self, __query=None, **kwargs):
+    def build_query(self, __query=None, _trusted=False, **kwargs):
         """
         build the MongoQ object from given kwargs
 
@@ -312,7 +312,7 @@ class Filter(object):
         if __query:
             q = __query
         else:
-            q = MongoQ(**kwargs)
+            q = MongoQ(_trusted=_trusted, **kwargs)
         return q
 
     @property

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 
+import threading
+
+from hashlib import sha256
+
 import tarfile
 from importlib import import_module
 
@@ -14,7 +18,7 @@ import warnings
 from base64 import b64encode
 from bson import UuidRepresentation
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, date
 from importlib.util import find_spec
 from pathlib import Path
 from shutil import rmtree
@@ -1000,37 +1004,68 @@ def migrate_unhashed_datasets(store):
 
 
 class MongoEncoder(json.JSONEncoder):
-    """ Special json encoder for numpy types
+    """ A safe encoder for mongodb
 
-    adopted from https://stackoverflow.com/a/49677241/890242
-                 https://stackoverflow.com/a/11875813/890242
+    Encoder for python object to its corresponding JSON/BSON-compatible type,
+    defaulting to a value's string representation if no other conversion is possible.
+    In this case a warning is issued to the user.
+
+    Usage:
+        collection.insert(mongo_compatible(obj))
+
+    See Also:
+        https://stackoverflow.com/a/49677241/890242
+        https://stackoverflow.com/a/11875813/890242
     """
 
     def default(self, obj):
+        # TODO improve for speed
         import numpy as np
-
-        if isinstance(obj, np.integer):
+        try:
+            from pandas.api.types import is_integer_dtype, is_float_dtype, is_array_like
+        except:
+            is_integer_dtype = lambda v: isinstance(v, int)
+            is_float_dtype = lambda v: isinstance(v, float)
+            is_array_like = lambda v: isinstance(v, (list, tuple, np.ndarray))
+        # PERF cosider rewrite using a MAP type => lambda v: cast(v)
+        #      e.g. return MAP[type(obj)](obj)
+        #      where MAP.__missing__ returns lambda v: str(v)
+        if isinstance(obj, (np.integer)):
             return int(obj)
         elif isinstance(obj, np.floating):
-            return float(obj)
+            return float(obj) if not np.isnan(obj) else None
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
         elif isinstance(obj, pd.DataFrame):
             return obj.to_dict(orient='records')
         elif isinstance(obj, pd.Series):
             return obj.tolist()
+        elif is_array_like(obj) and is_integer_dtype(obj):
+            return pd.to_numeric(obj, downcast='float')
+        elif is_array_like(obj) and is_float_dtype(obj):
+            return pd.to_numeric(obj, downcast='float')
         elif isinstance(obj, datetime):
             return obj.isoformat()
+        elif isinstance(obj, date):
+            return obj.isoformat()
         elif isinstance(obj, pd.Timedelta):
-            return obj.value()
+            return obj.value
         elif isinstance(obj, bytes):
             return b64encode(obj).decode('utf8')
         elif isinstance(obj, range):
             return list(obj)
-        return json.JSONEncoder.default(self, obj)
+        try:
+            # PERF consider doing this first, only check for special types on exception
+            return json.JSONEncoder.default(self, obj)
+        except Exception as e:
+            # ignore exception in favor of string repr
+            msg = f'Could not encode value of {type(obj)} natively due to {e}, resolved to str(obj)'
+            warnings.warn(msg)
+            pass
+        return str(obj)
 
 
-json_dumps_np = lambda *args, cls=None, **kwargs: json.dumps(*args, **kwargs, cls=cls or MongoEncoder)
+json_dumps_np = lambda *args, cls=None, fail=False, **kwargs: json.dumps(*args, **kwargs, cls=cls or MongoEncoder)
 mongo_compatible = lambda *args: json.loads(json_dumps_np(*args))
 
 
@@ -1115,6 +1150,10 @@ class ProcessLocal(dict):
         self._check_pid()
         return (self._cache or super()).__getitem__(k)
 
+    def __setitem__(self, k, v):
+        self._check_pid()
+        (self._cache or super()).__setitem__(k, v)
+
     def keys(self):
         self._check_pid()
         return (self._cache or super()).keys()
@@ -1137,7 +1176,8 @@ class KeepMissing(dict):
 
 
 def sec_validate_url(url):
-    assert validators.url(url, skip_ipv4_addr=True,
+    assert validators.url(url,
+                          skip_ipv4_addr=True,
                           skip_ipv6_addr=True), f"expected a http:// or https:// url, got {url}"
     assert url.startswith('http'), f"expected http:// or https:// url, got {url}"
     return True
@@ -1184,6 +1224,9 @@ def batched(iterable, batch_size):
         if not batch:
             break
         yield batch
+
+
+ensure_list = lambda v: v if isinstance(v, (list, tuple)) else list(v) if isinstance(v, range) else [v]
 
 
 def tqdm_if_interactive():
@@ -1236,3 +1279,10 @@ def is_interactive():
         if any(t in ipy_str for t in ('zmqshell', 'jupyter')):
             return True
     return sys.flags.interactive
+
+
+def signature(filter):
+    # sign a set of values
+    # SEC: CWE-345 ensure user-provided values are not tampered with
+    # -- this is used to ensure the values are not tampered with when passed to a query
+    return sha256((str(threading.get_ident()) + str(filter)).encode('utf-8')).hexdigest()


### PR DESCRIPTION
- in /service rest api, raise native exceptions as returned
- in datasets (mongodb and sqlalchemy) enable passing trusted filter kwargs, disabling injecting testing. trusted queries require a locally and salted hash of the filter kwargs, only available to local and interactive code
- allow local testing in test mode only
- support more types in mongo json encoder