### PR TITLE
ignore local mongoinit.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ mlruns/**
 .vscode/**
 .dccache
 omegaml/tests/**/*.db
+scripts/mongoinit.js


### PR DESCRIPTION
- avoid storing clear text keys