### PR TITLE
Add store objinfo

### DIFF
--- a/omegaml/__init__.py
+++ b/omegaml/__init__.py
@@ -47,9 +47,19 @@ scripts = _omega.OmegaDeferredInstance(_omega._om, 'scripts')
 runtime = _omega.OmegaDeferredInstance(_omega._om, 'runtime')
 #: stream helper
 streams = _omega.OmegaDeferredInstance(_omega._om, 'streams')
+#: buckets helper
+buckets = _omega.OmegaDeferredInstance(_omega._om, 'buckets')
 #: the OmegaSimpleLogger for easy log access
 logger = _omega.OmegaDeferredInstance(_omega._om, 'logger')
 #: the settings object
 defaults = _omega.OmegaDeferredInstance(_omega._om, 'defaults')
+#: list()
+list = _omega.OmegaDeferredInstance(_omega._om, 'list')
+#: stats()
+stats = _omega.OmegaDeferredInstance(_omega._om, 'stats')
+#: metadata
+metadata = _omega.OmegaDeferredInstance(_omega._om, 'metadata')
+#: help()
+help = _omega.OmegaDeferredInstance(_omega._om, 'help')
 #: status()
 status = _omega.OmegaDeferredInstance(_omega._om, 'status')

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -164,6 +164,7 @@ OMEGA_STORE_MIXINS = [
     'omegaml.mixins.store.passthrough.PassthroughMixin',
     'omegaml.mixins.store.tracking.TrackableMetadataMixin',
     'omegaml.mixins.store.tracking.UntrackableMetadataMixin',
+    'omegaml.mixins.store.objinfo.ObjectInformationMixin',
 ]
 #: set hashed or clear names
 OMEGA_STORE_HASHEDNAMES = truefalse(os.environ.get('OMEGA_STORE_HASHEDNAMES', True))

--- a/omegaml/mixins/store/objinfo.py
+++ b/omegaml/mixins/store/objinfo.py
@@ -1,0 +1,116 @@
+from omegaml.store import OmegaStore
+
+
+class ObjectInformationMixin:
+    _scale_map = {
+        'b': 1e0 * 1.024,  # bytes
+        'k': 1e3 * 1.024,  # kilobytes
+        'm': 1e6 * 1.024,  # megabytes
+        'g': 1e9 * 1.024,  # gigabytes
+        't': 1e12 * 1.024,  # terabytes
+    }
+
+    @classmethod
+    def supports(cls, obj, **kwargs):
+        # support all store types
+        return True
+
+    def summary(self, name):
+        self: OmegaStore | ObjectInformationMixin
+        meta = self.metadata(name)
+        backend = self.get_backend(name)
+        contrib = backend.summary(name) if hasattr(backend, 'summary') else {}
+        stats = self._get_collection_stats(meta.collection)
+        data = {
+            'name': name,
+            'kind': meta.kind,
+            'created': meta.created,
+            'modified': meta.modified,
+            'docs': meta.attributes.get('docs'),
+            'revisions': self.revisions(name) if hasattr(self, 'revisions') else None,
+            'size': stats.get('totalSize', 0),  # size in bytes
+            'count': max(stats.get('count', 0), 1)  # count of rows, always count at least 1 (the object itself)
+        }
+        data.update(contrib)
+        return data
+
+    def stats(self, pattern=None, scale=1.0, as_dict=False, **kwargs):
+        """ get statistics for all objects in the store
+
+        Args:
+            pattern (str): pattern to match object names
+            scale (float): scale size statistics by this factor, defaults to 1.0 (bytes), set to 1e3 for KB, 1e6 for MB,
+              1e9 for GB, etc.
+            as_dict (bool): if True, return statistics as dict, else as DataFrame, defaults to False
+            **kwargs:
+
+        Returns:
+            dict or DataFrame
+        """
+        self: OmegaStore | ObjectInformationMixin
+        _stats = {}
+        for meta in self.list(pattern=pattern, raw=True):
+            _stats[meta.name] = self._get_collection_stats(meta.collection, scale=scale)
+            _stats[meta.name].setdefault('count', 1)  # count is always at least 1 (the object itself)
+            _stats[meta.name].setdefault('totalSize', 0)  # if we don't know the size, assume 0
+            # TODO add gridfs file size for only this member, not gridfs overall
+            # self._get_collection_stats(f'{self._fs_collection}.chunks', scale=scale)
+        return _stats if as_dict else self._get_stats_dataframe(_stats)
+
+    def dbstats(self, scale=1.0, as_dict=False, **kwargs):
+        self: OmegaStore | ObjectInformationMixin
+        _stats = self._get_database_stats(scale=scale)
+        _stats.setdefault('fsUsedSize%', _stats.get('fsUsedSize', 0) / _stats.get('fsTotalSize', 1))
+        _stats.setdefault('fsAvailableSize%', _stats.get('fsAvailableSize', 0) / _stats.get('fsTotalSize', 1))
+        return _stats if as_dict else self._get_stats_dataframe(_stats, scale=scale,
+                                                                index=['db'], totals='fsTotalSize')
+
+    def _get_stats_dataframe(self, _stats, index=None, totals=None, scale=1.0):
+        # transform to dataframe with totals and percentages of each statistic
+        # -- index: store prefix, or 'db' for database stats
+        # -- columns: count, totalSize, count%, totalSize%, ...
+        # -- values: the actual values, and % values of total for each column
+        import pandas as pd
+        if not _stats:
+            return pd.DataFrame()
+        df = pd.DataFrame(_stats, index=index).T
+        totals = df.sum() if totals is None else df.loc[totals].sum()
+        df_pct = ((df / totals)
+                  .rename(columns={k: k + '%' for k in df.columns}))
+        _stats = (pd.concat([df, df_pct], axis=1))
+        _stats['units'] = scale
+        return _stats
+
+    def _get_collection_stats(self, collection, scale=1.0, keys=None):
+        # https://www.mongodb.com/docs/manual/reference/method/db.collection.totalSize/
+        self: OmegaStore | ObjectInformationMixin
+        keys = keys or ['count', 'totalSize']
+        scale = self._ensure_numeric_scale(scale)
+        try:
+            _stats = self.mongodb.command('collstats', collection, scale=scale)
+        except:
+            _stats = {}
+        return {
+            k: _stats[k]
+            for k in keys
+        } if _stats else {}
+
+    def _get_database_stats(self, scale=1.0, keys=None):
+        self: OmegaStore | ObjectInformationMixin
+        keys = keys or ['totalSize', 'fsUsedSize', 'fsTotalSize', 'fsAvailableSize']
+        scale = self._ensure_numeric_scale(scale)
+        # we calculate available size as total - used to simplify plotting code
+        try:
+            _stats = self.mongodb.command('dbstats', scale=scale)
+            _stats['fsAvailableSize'] = _stats['fsTotalSize'] - _stats['fsUsedSize']
+        except:
+            _stats = {'totalSize': 0, 'fsUsedSize': 0, 'fsTotalSize': 0, 'fsAvailableSize': 0}
+        return {
+            k: _stats[k]
+            for k in keys
+        }
+
+    def _ensure_numeric_scale(self, scale):
+        scale = self._scale_map.get(scale[0].lower(), scale) if isinstance(scale, str) else scale
+        scale = scale if scale >= 1.0 else 1 / scale  # support 1e+-n
+        return scale

--- a/omegaml/store/combined.py
+++ b/omegaml/store/combined.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+
+
 class CombinedOmegaStoreMixin:
     def __init__(self, stores):
         self._stores = stores
@@ -15,13 +18,51 @@ class CombinedOmegaStoreMixin:
         pattern = pattern or ''
         for store in self._stores:
             regexp = regexp.replace(store.prefix) if regexp else None
+            pattern = pattern.replace(store.prefix, '', 1)
             # list by name|pattern, return list of Metadata or list of names
-            members = store.list(pattern.replace(store.prefix, '', 1),
+            members = store.list(pattern=pattern,
                                  regexp=regexp, raw=raw, **kwargs)
             # either add obj:Metadata as is, or obj:str as 'prefix/name'
             add = lambda obj: f'{store.prefix}{obj}' if not raw else obj
             index.extend(add(obj) for obj in members)
         return index
+
+    def stats(self, pattern=None, regexp=None, summary=True, raw=False, scale=1.0,
+              as_dict=False, **kwargs):
+        """ return summary statistics by store
+
+        Args:
+            pattern (str): patterns of members to select, see .list() for details
+            regexp (str): regex of members to select, see .list() for details
+            summary (bool): if True, return summary statistics, else return raw statistics, defaults to True
+            raw (bool): if True, return detail statistics for each member, equivalent of calling .stats() on each member
+            scale (float): scale size statistics by this factor, defaults to 1.0 (bytes), set to 1e3 for KB, 1e6 for MB,
+              1e9 for GB, etc.
+            as_dict (bool): if True, return statistics as dict, else as DataFrame, defaults to False
+            **kwargs:
+
+        Returns:
+
+        """
+        _stats = defaultdict(dict)
+        raw = raw is True or not summary
+        for store in self._stores:
+            if not hasattr(store, 'stats'):
+                continue
+            prefix = store.prefix.replace('/', '').replace('data', 'datasets')
+            member_stats = store.stats(pattern=pattern, regexp=regexp, scale=scale, as_dict=True)
+            if raw:
+                _stats[prefix] = member_stats
+            else:
+                # summarize by store
+                # -- member_stats is a dict of {member: {stat: value, ...}, ...}
+                for mk, ms in member_stats.items():
+                    for k in ms:
+                        _stats[prefix].update({
+                            # we count the number of members, not their collection size (in rows)
+                            k: _stats[prefix].get(k, 0) + (1 if k == 'count' else ms[k])
+                        })
+        return _stats if as_dict else self.store_by_prefix('data')._get_stats_dataframe(_stats, scale=scale)
 
     def help(self, name_or_obj):
         import sys
@@ -45,6 +86,7 @@ class CombinedOmegaStoreMixin:
 
     def store_by_prefix(self, prefix):
         prefix = prefix.replace('datasets/', 'data/')
+        prefix = prefix + '/' if not prefix.endswith('/') else prefix
         for store in self._stores:
             if store.prefix == prefix:
                 return store

--- a/omegaml/store/streams.py
+++ b/omegaml/store/streams.py
@@ -103,12 +103,13 @@ class StreamsProxy(OmegaStore):
     def getl(self, name, **kwargs):
         return self.get(name, lazy=True, **kwargs)
 
-    def drop(self, name, force=False):
+    def drop(self, name, force=False, keep_data=True, **kwargs):
         meta = self.metadata(name)
         if meta is None and not force:
             raise DoesNotExist()
         stream = self.get(name)
-        stream.buffer().delete()
+        if not keep_data:
+            stream.buffer().delete()
         stream.delete()
         meta.delete() if meta is not None else None
         return True

--- a/omegaml/tests/core/test_objinfo.py
+++ b/omegaml/tests/core/test_objinfo.py
@@ -1,0 +1,87 @@
+from unittest import TestCase
+
+import pandas as pd
+from omegaml import Omega
+from omegaml.mixins.store.objinfo import ObjectInformationMixin
+from omegaml.tests.util import OmegaTestMixin
+from pprint import pprint
+
+
+class ObjectInformationMixinTests(OmegaTestMixin, TestCase):
+    def setUp(self):
+        self.om = om = Omega()
+        om.datasets.register_mixin(ObjectInformationMixin)
+        self.clean()
+
+    def test_summary(self):
+        om = self.om
+        data = [1, 2, 3]
+        om.datasets.put(data, 'test', attributes={
+            'docs': 'foobar'
+        })
+        summary = om.datasets.summary('test')
+        self.assertIsInstance(summary, dict)
+        self.assertIn('docs', summary)
+
+    def test_stats_mixin(self):
+        om = self.om
+        data = {'foo': 'bar'}
+        om.datasets.put(data, 'test')
+        stats = om.datasets.stats('test', as_dict=True)
+        self.assertIn('totalSize', stats['test'])
+
+    def test_all_store_stats(self):
+        om = self.om
+        data = {'foo': 'bar'}
+        om.datasets.put(data, 'test')
+        om.datasets.put(data, 'test2')
+        om.models.put(data, 'test2')
+        # get stats for all stores, in bytes
+        bytes_stats = om.stats(as_dict=True)
+        pprint(bytes_stats)
+        self.assertIn('datasets', bytes_stats)
+        self.assertIn('models', bytes_stats)
+        self.assertEqual(bytes_stats['datasets']['count'], 2)
+        self.assertEqual(bytes_stats['models']['count'], 1)
+        # test we can get stats for each scale factor
+        for scale, scalef in [('kb', 1e3), ('mb', 1e6), ('gb', 1e9), ('tb', 1e12)]:
+            # by scale factor as a string
+            stats = om.stats(scale=scale, as_dict=True)
+            self.assertIn('datasets', stats)
+            self.assertIn('models', stats)
+            self.assertEqual(stats['datasets']['count'], 2)
+            self.assertEqual(stats['models']['count'], 1)
+            self.assertEqual(stats['datasets']['totalSize'],
+                             bytes_stats['datasets']['totalSize'] // scalef)
+            # by scale factor as a float
+            stats = om.stats(scale=scalef, as_dict=True)
+            self.assertIn('datasets', stats)
+            self.assertIn('models', stats)
+            self.assertEqual(stats['datasets']['count'], 2)
+            self.assertEqual(stats['models']['count'], 1)
+            self.assertEqual(stats['datasets']['totalSize'],
+                             bytes_stats['datasets']['totalSize'] // scalef)
+
+    def test_all_store_stats_as_df(self):
+        om = self.om
+        data = {'foo': 'bar'}
+        om.datasets.put(data, 'test')
+        om.datasets.put(data, 'test2')
+        om.models.put(data, 'test2')
+        # get stats for all stores, in bytes
+        bytes_stats = om.stats()
+        self.assertIsInstance(bytes_stats, pd.DataFrame)
+        self.assertIn('datasets', bytes_stats.index)
+        self.assertIn('models', bytes_stats.index)
+        self.assertEqual(bytes_stats.loc['datasets']['count'], 2)
+        self.assertEqual(bytes_stats.loc['models']['count'], 1)
+
+    def test_dbstats(self):
+        om = self.om
+        dbstats = om.datasets.dbstats(as_dict=True)
+        self.assertIsInstance(dbstats, dict)
+        self.assertIn('fsAvailableSize', dbstats)
+        self.assertIn('fsUsedSize', dbstats)
+        self.assertIn('fsTotalSize', dbstats)
+        self.assertIn('fsUsedSize%', dbstats)
+        self.assertIn('fsAvailableSize%', dbstats)

--- a/omegaml/tests/core/test_store.py
+++ b/omegaml/tests/core/test_store.py
@@ -683,6 +683,36 @@ class StoreTests(unittest.TestCase):
             raised = True
         self.assertFalse(raised)
 
+    def test_drop_many(self):
+        data = {
+            'a': list(range(1, 10)),
+            'b': list(range(1, 10))
+        }
+        df = pd.DataFrame(data)
+        store = OmegaStore()
+        store.put(df, 'foo', as_hdf=True)
+        store.put(df, 'fox')
+        # drop multiple objects
+        # -- get a report
+        results = store.drop('fo*', report=True)
+        self.assertEqual(results, {'foo': True, 'fox': True})
+        self.assertEqual(store.list('foo'), [])
+        self.assertEqual(store.list('fox'), [])
+        # -- just drop, as usually expect true or false
+        store.put(df, 'foo', as_hdf=True)
+        store.put(df, 'fox')
+        self.assertTrue(store.drop('fo*', report=True))
+        self.assertEqual(store.list('foo'), [])
+        self.assertEqual(store.list('fox'), [])
+        with self.assertRaises(DoesNotExist):
+            store.drop('bo*')
+        try:
+            store.drop('bo*', force=True)
+            raised = False
+        except:
+            raised = True
+        self.assertFalse(raised)
+
     def test_list_raw(self):
         data = {
             'a': list(range(1, 10)),

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -603,7 +603,7 @@ def extend_instance(obj, cls, *args, conditional=None, **kwargs):
     should_apply = True if not callable(conditional) else conditional(cls, obj)
     if should_apply and cls not in base_mro:
         base_cls = obj.__class__
-        base_cls_name = base_mro[-2].__name__
+        base_cls_name = base_cls.__name__
         obj.__class__ = type(base_cls_name, (cls, base_cls), {})
     if hasattr(obj, '_init_mixin'):
         obj._init_mixin(*args, **kwargs)


### PR DESCRIPTION
- om.stats(), store.stats() provide storage object information
- improve om top-level module ux: om.buckets(), om.list(), om.stats(), om.metadata(), om.help()
- mixins now provide the base cls name instead of the top-level (improves help())