### PR TITLE
feat: enable sliced query of tracking data, improve stats

### DIFF
--- a/omegaml/backends/tracking/base.py
+++ b/omegaml/backends/tracking/base.py
@@ -1,6 +1,9 @@
 import getpass
+import logging
 
 from omegaml import settings, load_class
+
+logger = logging.getLogger(__name__)
 
 
 class TrackingProvider:
@@ -127,7 +130,9 @@ class TrackingProvider:
         store = store or self._model_store
         mon = self._has_monitor(obj, store=store)
         is_autotracked = getattr(self, 'autotrack', False)
-        assert is_autotracked, "experiments must be auto-tracking for monitoring, ensure .experiment(autotrack=True)"
+        if not is_autotracked:
+            logger.warning(
+                f"Experiment {self._experiment} is not autotracked, model calls are not tracked automatically")
         provider = provider or mon.get('provider') if mon else None
         provider = provider or store.prefix.replace('/', '')
         store.link_monitor(obj, self._experiment, provider=provider, alerts=alerts, schedule=schedule)

--- a/omegaml/backends/tracking/experiment.py
+++ b/omegaml/backends/tracking/experiment.py
@@ -1,7 +1,10 @@
+import logging
 import os
 
 from omegaml.backends.basemodel import BaseModelBackend
 from omegaml.backends.tracking.base import TrackingProvider
+
+logger = logging.getLogger(__name__)
 
 
 class ExperimentBackend(BaseModelBackend):
@@ -73,7 +76,6 @@ class ExperimentBackend(BaseModelBackend):
     def get(self, name, raw=False, data_store=None, **kwargs):
         assert data_store is not None, "experiments require a datastore, specify data_store=om.datasets"
         tracker = super().get(name, **kwargs)
-        name = os.path.basename(name)
         tracker._store = data_store
         tracker._model_store = self.model_store
         # fix for #452, maintain backwards compatibility

--- a/omegaml/tests/core/test_tracking.py
+++ b/omegaml/tests/core/test_tracking.py
@@ -462,6 +462,21 @@ class TrackingTestCases(OmegaTestMixin, unittest.TestCase):
             total_rows = sum(len(rows) for rows in data if isinstance(rows, result_type))
             self.assertEqual(total_rows, 10 * 3)  # each run has 3 events
 
+    def test_data_slice(self):
+        om = self.om
+        for i in range(10):
+            with om.runtime.experiment('myexp') as exp:
+                exp.log_metric('accuracy', i)
+            exp.flush()
+        # slice on records
+        data = exp.data(run='*', slice=slice(0, 5))
+        self.assertEqual(len(data), 5)
+        data = exp.data(run='*', slice=(3, 3 + 2))
+        self.assertEqual(len(data), 2)
+        # slice on runs
+        data = exp.data(run=slice(0, 5))
+        self.assertEqual(len(data), 5 * 3)  # every run has 3 events (start, metric, stop)
+
     def test_current_vs_all_data(self):
         om = self.om
         for i in range(10):

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -1084,7 +1084,7 @@ def tryOr(fn, else_fn):
     # try fn(), if exception call else_fn() if callable, return its value otherwise
     try:
         return fn()
-    except:
+    except Exception:
         return else_fn() if callable(else_fn) else else_fn
 
 
@@ -1229,7 +1229,7 @@ def tarfile_safe_extractall(tar, dest_path, filter='data'):
 def batched(iterable, batch_size):
     """ split an iterable into batches of batch_size """
     from itertools import islice
-    it = iter(iterable)
+    it = iter(iterable) if iterable else []
     while True:
         batch = list(islice(it, batch_size))
         if not batch:
@@ -1332,3 +1332,11 @@ def signature(filter):
 def utcnow():
     # replacing datetime.utcnow() with datetime.now(timezone.utc)
     return datetime.now(timezone.utc)
+
+
+def ensurelist(l):
+    # ensure we have a python list() from a numpy array
+    import numpy as np
+    return l.tolist() if isinstance(l, np.ndarray) else list(l)
+
+


### PR DESCRIPTION
- tracker.data() supports run=<slice> to specify a range of runs
- tracker.stats.metrics() are computed by run, not all runs by default