### PR TITLE
fix: setuptools.sandbox is no longer available

### DIFF
--- a/omegaml/backends/package/packager.py
+++ b/omegaml/backends/package/packager.py
@@ -8,14 +8,12 @@ logger = logging.getLogger(__name__)
 
 
 def build_sdist(src, distdir):
-    # TODO replace with python -m build
-    #      https://setuptools.pypa.io/en/latest/userguide/quickstart.html
-    from setuptools.sandbox import run_setup
-    if not src.endswith('setup.py'):
-        setup_path = os.path.join(src, 'setup.py')
-    else:
-        setup_path = src
-    run_setup(setup_path, ['sdist', '--dist-dir', distdir])
+    # uses the build package to create a source distribution
+    # -- see https://build.pypa.io/en/stable/api.html#build.ProjectBuilder
+    from build import ProjectBuilder
+    setup_path = Path(src.replace('setup.py', ''))
+    builder = ProjectBuilder(setup_path)
+    builder.build('sdist', output_directory=distdir)
     sdist = sorted(Path(distdir).iterdir(), key=os.path.getmtime)[-1]
     return str(sdist)
 

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ install_deps = [
     'sqlalchemy<2',  # currently no support for sqlalchemy 2
     'minibatch[omegaml]',  # required for streaming
     'validators',  # required for sec validations
+    'build',  # required to build packages
 ]
 setup(
     name='omegaml',


### PR DESCRIPTION
- replace setuptools with build, a simple build front end
- this enables use of pyproject.toml
- see https://build.pypa.io/en/stable/