### PR TITLE
chore: refactor basic Python and Pandas data types handling

### DIFF
--- a/omegaml/__init__.py
+++ b/omegaml/__init__.py
@@ -40,7 +40,7 @@ _omega.OmegaDeferredInstance = getattr(_omega, 'OmegaDeferredInstance', OmegaDef
 datasets = _omega.OmegaDeferredInstance(_omega._om, 'datasets')
 #: the :class:`omegaml.store.base.OmegaStore` store for models
 models = _omega.OmegaDeferredInstance(_omega._om, 'models')
-#: the :class:`omegaml.notebook.jobs.OmegaJobs` store for jobs
+#: the :class:`omegaml.store.base.OmegaStore` store for jobs
 jobs = _omega.OmegaDeferredInstance(_omega._om, 'jobs')
 #: the :class:`omegaml.store.base.OmegaStore` store for scripts
 scripts = _omega.OmegaDeferredInstance(_omega._om, 'scripts')

--- a/omegaml/backends/coreobjects.py
+++ b/omegaml/backends/coreobjects.py
@@ -1,0 +1,561 @@
+import os
+import tempfile
+from datetime import datetime
+
+import gridfs
+from mongoengine import GridFSProxy
+
+from omegaml.backends.basedata import BaseDataBackend
+from omegaml.documents import MDREGISTRY
+from omegaml.store import MongoQueryOps, Filter
+from omegaml.store.fastinsert import fast_insert, default_chunksize
+from omegaml.store.queryops import sanitize_filter
+from omegaml.util import is_dataframe, is_series, is_ndarray, ensure_index, unravel_index, jsonescape, \
+    cursor_to_dataframe, convert_dtypes, restore_index, signature, make_tuple, mongo_compatible
+
+
+class CoreObjectsBackend(BaseDataBackend):
+    """ Provides Python and pandas basic types storage
+
+    Notes:
+        * to stay backwards compatible, the backend uses KIND="core.object", however the actual
+          Metadata.kind used for various objects are defined in omegaml.documents.MDREGISTRY as PANDAS_DFROWS,
+          PANDAS_SEROWS, PANDAS_DFGROUP, PYTHON_DATA, PANDAS_HDF
+
+    .. versionadded:: NEXT
+        refactored from omegaml.store.base.OmegaStore
+    """
+    KIND = "core.object"
+    # additional kinds registered in store.defaults.OMEGA_STORE_BACKENDS
+    # -- see OmegaStore.register_backend()
+    KIND_EXT = (MDREGISTRY.PANDAS_DFROWS, MDREGISTRY.PANDAS_SEROWS, MDREGISTRY.PANDAS_DFGROUP,
+                MDREGISTRY.PYTHON_DATA, MDREGISTRY.PANDAS_HDF)
+
+    @classmethod
+    def supports(self, obj, name, **kwargs):
+        return is_dataframe(obj) | is_series(obj) | is_ndarray(obj) | isinstance(obj, (dict, list, tuple))
+
+    def get(self, name, version=-1, force_python=False, lazy=False, **kwargs):
+        meta = self.store.metadata(name, version=version)
+        if meta.kind == MDREGISTRY.PANDAS_DFROWS:
+            return self.get_dataframe_documents(name, version=version, lazy=lazy, **kwargs)
+        elif meta.kind == MDREGISTRY.PANDAS_SEROWS:
+            return self.get_dataframe_documents(name, version=version, lazy=lazy, is_series=True, **kwargs)
+
+        elif meta.kind == MDREGISTRY.PANDAS_DFGROUP:
+            return self.get_dataframe_dfgroup(name, version=version, lazy=lazy, **kwargs)
+        elif meta.kind == MDREGISTRY.PYTHON_DATA:
+            return self.get_python_data(name, version=version, lazy=lazy, **kwargs)
+        elif meta.kind == MDREGISTRY.PANDAS_HDF:
+            return self.get_dataframe_hdf(name, version=version)
+        return self.get_object_as_python(meta, version=version)
+
+    def put(self, obj, name, attributes=None, **kwargs):
+        if is_dataframe(obj) or is_series(obj):
+            groupby = kwargs.get('groupby')
+            if obj.empty:
+                from warnings import warn
+                warn(
+                    'Provided dataframe is empty, ignoring it, doing nothing here!')
+                return None
+            if kwargs.pop('as_hdf', False):
+                return self.put_dataframe_as_hdf(
+                    obj, name, attributes, **kwargs)
+            elif groupby:
+                return self.put_dataframe_as_dfgroup(
+                    obj, name, groupby, attributes)
+            append = kwargs.pop('append', None)
+            timestamp = kwargs.pop('timestamp', None)
+            index = kwargs.pop('index', None)
+            chunksize = kwargs.pop('chunksize', default_chunksize)
+            return self.put_dataframe_as_documents(
+                obj, name, append=append, attributes=attributes, index=index,
+                timestamp=timestamp, chunksize=chunksize, **kwargs)
+        elif is_ndarray(obj):
+            if kwargs.pop('as_pydata', False):
+                return self.put_pyobj_as_document(obj.tolist(), name,
+                                                  attributes=attributes, **kwargs)
+            return self.put_ndarray_as_hdf(obj, name, attributes=attributes,
+                                           **kwargs)
+        elif isinstance(obj, (dict, list, tuple)):
+            kwargs.pop('as_pydata', None)
+            if kwargs.pop('as_hdf', False):
+                return self.put_pyobj_as_hdf(obj, name,
+                                             attributes=attributes, **kwargs)
+            return self.put_pyobj_as_document(obj, name,
+                                              attributes=attributes, **kwargs)
+        raise TypeError('type %s not supported' % type(obj))
+
+    @property
+    def collection(self):
+        return self.data_store.collection
+
+    @property
+    def store(self):
+        return self.data_store
+
+    def put_dataframe_as_documents(self, obj, name, append=None,
+                                   attributes=None, index=None,
+                                   timestamp=None, chunksize=None,
+                                   ensure_compat=True, _fast_insert=fast_insert,
+                                   **kwargs):
+        """
+        store a dataframe as a row-wise collection of documents
+
+        :param obj: the dataframe to store
+        :param name: the name of the item in the store
+        :param append: if False collection will be dropped before inserting,
+           if True existing documents will persist. Defaults to True. If not
+           specified and rows have been previously inserted, will issue a
+           warning.
+        :param index: list of columns, using +, -, @ as a column prefix to
+           specify ASCENDING, DESCENDING, GEOSPHERE respectively. For @ the
+           column has to represent a valid GeoJSON object.
+        :param timestamp: if True or a field name adds a timestamp. If the
+           value is a boolean or datetime, uses _created as the field name.
+           The timestamp is always datetime.datetime.utcnow(). May be overriden
+           by specifying the tuple (col, datetime).
+        :param ensure_compat: if True attempt to convert obj to mongodb compatibility,
+           set to False only if you are sure to have only compatible values in dataframe.
+           defaults to True. False may reduce memory and increase speed on large dataframes.
+        :return: the Metadata object created
+        """
+        import pandas as pd
+        collection = self.collection(name)
+        if is_series(obj):
+            import pandas as pd
+            obj = pd.DataFrame(obj, index=obj.index, columns=[str(obj.name)])
+            store_series = True
+        else:
+            store_series = False
+        if append is False:
+            self.drop(name, force=True)
+        elif append is None and collection.count_documents({}, limit=1):
+            from warnings import warn
+            warn('%s already exists, will append rows' % name)
+        if index:
+            # get index keys
+            if isinstance(index, dict):
+                idx_kwargs = index
+                index = index.pop('columns')
+            else:
+                idx_kwargs = {}
+            # create index with appropriate options
+            keys, idx_kwargs = MongoQueryOps().make_index(index, **idx_kwargs)
+            ensure_index(collection, keys, **idx_kwargs)
+        if timestamp:
+            dt = datetime.utcnow()
+            if isinstance(timestamp, bool):
+                col = '_created'
+            elif isinstance(timestamp, str):
+                col = timestamp
+            elif isinstance(timestamp, datetime):
+                col, dt = '_created', timestamp
+            elif isinstance(timestamp, tuple):
+                col, dt = timestamp
+            else:
+                col = '_created'
+            obj[col] = dt
+        # store dataframe indicies
+        # FIXME this may be a performance issue, use size stored on stats or metadata
+        row_count = self.collection(name).estimated_document_count()
+        # fixes #466, ensure column names are strings in a multiindex
+        if isinstance(obj.columns, pd.MultiIndex):
+            obj.columns = obj.columns.map('_'.join)
+        obj, idx_meta = unravel_index(obj, row_count=row_count)
+        stored_columns = [jsonescape(col) for col in obj.columns]
+        column_map = list(zip(obj.columns, stored_columns))
+        d_column_map = dict(column_map)
+        dtypes = {
+            d_column_map.get(k): v.name
+            for k, v in obj.dtypes.items()
+        }
+        kind_meta = {
+            'columns': column_map,
+            'dtypes': dtypes,
+            'idx_meta': idx_meta
+        }
+        # ensure column names to be strings
+        obj.columns = stored_columns
+        # create mongon indicies for data frame index columns
+        df_idxcols = [col for col in obj.columns if col.startswith('_idx#')]
+        if df_idxcols:
+            keys, idx_kwargs = MongoQueryOps().make_index(df_idxcols)
+            ensure_index(collection, keys, **idx_kwargs)
+        # create index on row id
+        keys, idx_kwargs = MongoQueryOps().make_index(['_om#rowid'])
+        ensure_index(collection, keys, **idx_kwargs)
+        # bulk insert
+        # -- get native objects
+        # -- seems to be required since pymongo 3.3.x. if not converted
+        #    pymongo raises Cannot Encode object for int64 types
+        if ensure_compat:
+            for col, col_dtype in dtypes.items():
+                if 'datetime' in col_dtype:
+                    obj[col].fillna('', inplace=True)
+        obj = obj.astype('O', errors='ignore')
+        _fast_insert(obj, self, name, chunksize=chunksize)
+        kind = (MDREGISTRY.PANDAS_SEROWS
+                if store_series
+                else MDREGISTRY.PANDAS_DFROWS)
+        meta = self.store._make_metadata(name=name,
+                                         prefix=self.store.prefix,
+                                         bucket=self.store.bucket,
+                                         kind=kind,
+                                         kind_meta=kind_meta,
+                                         attributes=attributes,
+                                         collection=collection.name)
+        return meta.save()
+
+    def put_dataframe_as_dfgroup(self, obj, name, groupby, attributes=None):
+        """
+        store a dataframe grouped by columns in a mongo document
+
+        :Example:
+
+          > # each group
+          >  {
+          >     #group keys
+          >     key: val,
+          >     _data: [
+          >      # only data keys
+          >        { key: val, ... }
+          >     ]}
+
+        """
+
+        def row_to_doc(obj):
+            for gval, gdf in obj.groupby(groupby):
+                if hasattr(gval, 'astype'):
+                    gval = make_tuple(gval.astype('O'))
+                else:
+                    gval = make_tuple(gval)
+                doc = dict(zip(groupby, gval))
+                datacols = list(set(gdf.columns) - set(groupby))
+                doc['_data'] = gdf[datacols].astype('O').to_dict('records')
+                yield doc
+
+        datastore = self.collection(name)
+        datastore.drop()
+        datastore.insert_many(row_to_doc(obj))
+        return self.store._make_metadata(name=name,
+                                         prefix=self.store.prefix,
+                                         bucket=self.store.bucket,
+                                         kind=MDREGISTRY.PANDAS_DFGROUP,
+                                         attributes=attributes,
+                                         collection=datastore.name).save()
+
+    def put_dataframe_as_hdf(self, obj, name, attributes=None, **kwargs):
+        filename = self.store.object_store_key(name, '.hdf')
+        hdffname = self._package_dataframe2hdf(obj, filename)
+        with open(hdffname, 'rb') as fhdf:
+            fileid = self.store.fs.put(fhdf, filename=filename)
+        return self.store._make_metadata(name=name,
+                                         prefix=self.store.prefix,
+                                         bucket=self.store.bucket,
+                                         kind=MDREGISTRY.PANDAS_HDF,
+                                         attributes=attributes,
+                                         gridfile=GridFSProxy(db_alias=self.store._dbalias,
+                                                              grid_id=fileid)).save()
+
+    def put_ndarray_as_hdf(self, obj, name, attributes=None, **kwargs):
+        """ store numpy array as hdf
+
+        this is hack, converting the array to a dataframe then storing
+        it
+        """
+        import pandas as pd
+        df = pd.DataFrame(obj)
+        return self.put_dataframe_as_hdf(df, name, attributes=attributes)
+
+    def put_pyobj_as_hdf(self, obj, name, attributes=None, **kwargs):
+        """
+        store list, tuple, dict as hdf
+
+        this requires the list, tuple or dict to be convertible into
+        a dataframe
+        """
+        import pandas as pd
+        df = pd.DataFrame(obj)
+        return self.put_dataframe_as_hdf(df, name, attributes=attributes)
+
+    def put_pyobj_as_document(self, obj, name, attributes=None, append=True, index=None, as_many=None, **kwargs):
+        """
+        store a dict as a document
+
+        similar to put_dataframe_as_documents no data will be replaced by
+        default. that is, obj is appended as new documents into the objects'
+        mongo collection. to replace the data, specify append=False.
+        """
+        collection = self.collection(name)
+        if append is False:
+            collection.drop()
+        elif append is None and collection.esimated_document_count(limit=1):
+            from warnings import warn
+            warn('%s already exists, will append rows' % name)
+        if index:
+            # create index with appropriate options
+            from omegaml.store import MongoQueryOps
+            if isinstance(index, dict):
+                idx_kwargs = index
+                index = index.pop('columns')
+            else:
+                idx_kwargs = {}
+            index = [f'data.{c}' for c in index]
+            keys, idx_kwargs = MongoQueryOps().make_index(index, **idx_kwargs)
+            ensure_index(collection, keys, **idx_kwargs)
+        if as_many is None:
+            as_many = isinstance(obj, (list, tuple)) and isinstance(obj[0], (list, tuple))
+        if as_many:
+            # list of lists are inserted as many objects, as in pymongo < 4
+            records = (mongo_compatible({'data': item}) for item in obj)
+            result = collection.insert_many(records)
+            objid = result.inserted_ids[-1]
+        else:
+            result = collection.insert_one(mongo_compatible({'data': obj}))
+            objid = result.inserted_id
+
+        return self.store._make_metadata(name=name,
+                                         prefix=self.store.prefix,
+                                         bucket=self.store.bucket,
+                                         kind=MDREGISTRY.PYTHON_DATA,
+                                         collection=collection.name,
+                                         attributes=attributes,
+                                         objid=objid).save()
+
+    def get_dataframe_documents(self, name, columns=None, lazy=False,
+                                filter=None, version=-1, is_series=False,
+                                chunksize=None, sanitize=True, trusted=None,
+                                **kwargs):
+        """
+        Internal method to return DataFrame from documents
+
+        :param name: the name of the object (str)
+        :param columns: the column projection as a list of column names
+        :param lazy: if True returns a lazy representation as an MDataFrame.
+           If False retrieves all data and returns a DataFrame (default)
+        :param filter: the filter to be applied as a column__op=value dict
+        :param sanitize: sanitize filter by removing all $op filter keys,
+          defaults to True. Specify False to allow $op filter keys. $where
+          is always removed as it is considered unsafe.
+        :param version: the version to retrieve (not supported)
+        :param is_series: if True retruns a Series instead of a DataFrame
+        :param kwargs: remaining kwargs are used a filter. The filter kwarg
+           overrides other kwargs.
+        :return: the retrieved object (DataFrame, Series or MDataFrame)
+
+        """
+        from omegaml.store.queryops import sanitize_filter
+        from omegaml.store.filtered import FilteredCollection
+
+        collection = self.collection(name)
+        meta = self.store.metadata(name)
+        filter = filter or kwargs
+        filter = sanitize_filter(filter, no_ops=sanitize, trusted=trusted)
+        if lazy or chunksize:
+            from ..mdataframe import MDataFrame
+            df = MDataFrame(collection,
+                            metadata=meta.kind_meta,
+                            columns=columns).query(**filter)
+            if is_series:
+                df = df[0]
+            if chunksize is not None and chunksize > 0:
+                return df.iterchunks(chunksize=chunksize)
+        else:
+            # TODO ensure the same processing is applied in MDataFrame
+            # TODO this method should always use a MDataFrame disregarding lazy
+            if filter:
+                query = Filter(collection, **filter).query
+                cursor = FilteredCollection(collection).find(filter=query, projection=columns)
+            else:
+                cursor = FilteredCollection(collection).find(projection=columns)
+            # restore dataframe
+            df = cursor_to_dataframe(cursor)
+            if '_id' in df.columns:
+                del df['_id']
+            if hasattr(meta, 'kind_meta'):
+                df = convert_dtypes(df, meta.kind_meta.get('dtypes', {}))
+            # -- restore columns
+            meta_columns = dict(meta.kind_meta.get('columns'))
+            if meta_columns:
+                # apply projection, if any
+                if columns:
+                    # get only projected columns
+                    # meta_columns is {origin_column: stored_column}
+                    orig_columns = dict({k: v for k, v in meta_columns.items()
+                                         if k in columns or v in columns})
+                else:
+                    # restore columns to original name
+                    orig_columns = meta_columns
+                df.rename(columns=orig_columns, inplace=True)
+            # -- restore indexes
+            idx_meta = meta.kind_meta.get('idx_meta')
+            if idx_meta:
+                df = restore_index(df, idx_meta)
+            # -- restore row order
+            if is_series:
+                index = df.index
+                name = df.columns[0]
+                df = df[name]
+                df.index = index
+                df.name = None if name == 'None' else name
+        return df
+
+    def rebuild_params(self, kwargs, collection):
+        """
+        Returns a modified set of parameters for querying mongodb
+        based on how the mongo document is structured and the
+        fields the document is grouped by.
+
+        **Note: Explicitly to be used with get_grouped_data only**
+
+        :param kwargs: Mongo filter arguments
+        :param collection: The name of mongodb collection
+        :return: Returns a set of parameters as dictionary.
+        """
+        modified_params = {}
+        db_structure = collection.find_one({}, {'_id': False})
+        groupby_columns = list(set(db_structure.keys()) - set(['_data']))
+        if kwargs is not None:
+            for item in kwargs:
+                if item not in groupby_columns:
+                    modified_query_param = '_data.' + item
+                    modified_params[modified_query_param] = kwargs.get(item)
+                else:
+                    modified_params[item] = kwargs.get(item)
+        return modified_params
+
+    def get_dataframe_dfgroup(self, name, version=-1, sanitize=True, lazy=False, **kwargs):
+        """
+        Return a grouped dataframe
+
+        :param name: the name of the object
+        :param version: not supported
+        :param kwargs: mongo db query arguments to be passed to
+               collection.find() as a filter.
+        :param sanitize: remove any $op operators in kwargs
+
+        .. versionchanged:: NEXT
+            filters are now specified as **kwargs, not kwargs= (still supported for backwards compatibility)
+
+        """
+        import pandas as pd
+        from omegaml.store.queryops import sanitize_filter
+        from omegaml.store.filtered import FilteredCollection
+
+        def convert_doc_to_row(cursor):
+            for doc in cursor:
+                data = doc.pop('_data', [])
+                for row in data:
+                    doc.update(row)
+                    yield doc
+
+        datastore = FilteredCollection(self.collection(name))
+        kwargs = kwargs.get('kwargs', kwargs)  # support backwards-compatible kwargs=
+        params = self.rebuild_params(kwargs, datastore)
+        if lazy:
+            return FilteredCollection(datastore, query=params)
+        params = sanitize_filter(params, no_ops=sanitize)
+        cursor = datastore.find(params, projection={'_id': False})
+        df = pd.DataFrame(convert_doc_to_row(cursor))
+        return df
+
+    def get_dataframe_hdf(self, name, version=-1):
+        """
+        Retrieve dataframe from hdf
+
+        :param name: The name of object
+        :param version: The version of object (not supported)
+        :return: Returns a python pandas dataframe
+        :raises: gridfs.errors.NoFile
+        """
+        df = None
+        meta = self.store.metadata(name)
+        filename = getattr(meta.gridfile, 'name', self.store.object_store_key(name, '.hdf'))
+        if self.store.fs.exists(filename=filename):
+            df = self._extract_dataframe_hdf(filename, version=version)
+            return df
+        else:
+            raise gridfs.errors.NoFile(
+                "{0} does not exist in mongo collection '{1}'".format(
+                    name, self.store.bucket))
+
+    def get_python_data(self, name, filter=None, version=-1, lazy=False, trusted=False, **kwargs):
+        """
+        Retrieve objects as python data
+
+        :param name: The name of object
+        :param version: The version of object
+
+        :return: Returns the object as python list object
+        """
+        datastore = self.collection(name)
+        filter = filter or kwargs
+        sanitize_filter(filter) if trusted is False or trusted != signature(filter) else filter
+        cursor = datastore.find(filter, **kwargs)
+        if lazy:
+            return cursor
+        data = (d.get('data') for d in cursor)
+        return list(data)
+
+    def get_object_as_python(self, meta, version=-1):
+        """
+        Retrieve object as python object
+
+        :param meta: The metadata object
+        :param version: The version of the object
+
+        :return: Returns data as python object
+        """
+        if meta.kind == MDREGISTRY.SKLEARN_JOBLIB:
+            return meta.gridfile
+        if meta.kind == MDREGISTRY.PANDAS_HDF:
+            return meta.gridfile
+        if meta.kind == MDREGISTRY.PANDAS_DFROWS:
+            return list(getattr(self.store.mongodb, meta.collection).find())
+        if meta.kind == MDREGISTRY.PYTHON_DATA:
+            col = getattr(self.store.mongodb, meta.collection)
+            return col.find_one(dict(_id=meta.objid)).get('data')
+        raise TypeError('cannot return kind %s as a python object' % meta.kind)
+
+    def _package_dataframe2hdf(self, df, filename, key=None):
+        """
+        Package a dataframe as a hdf file
+
+        :param df: The dataframe
+        :param filename: Name of file
+
+        :return: Filename of hdf file
+        """
+        lpath = tempfile.mkdtemp()
+        fname = os.path.basename(filename)
+        hdffname = os.path.join(self.store.tmppath, fname + '.hdf')
+        key = key or 'data'
+        df.to_hdf(hdffname, key)
+        return hdffname
+
+    def _extract_dataframe_hdf(self, filename, version=-1):
+        """
+        Extracts a dataframe from a stored hdf file
+
+        :param filename: The name of file
+        :param version: The version of file
+
+        :return: Pandas dataframe
+        """
+        import pandas as pd
+        hdffname = os.path.join(self.store.tmppath, filename)
+        dirname = os.path.dirname(hdffname)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        try:
+            outf = self.store.fs.get_version(filename, version=version)
+        except gridfs.errors.NoFile as e:
+            raise e
+        with open(hdffname, 'wb') as hdff:
+            hdff.write(outf.read())
+        hdf = pd.HDFStore(hdffname)
+        key = list(hdf.keys())[0]
+        df = hdf[key]
+        hdf.close()
+        return df

--- a/omegaml/backends/scikitlearn.py
+++ b/omegaml/backends/scikitlearn.py
@@ -1,15 +1,14 @@
 from __future__ import absolute_import
 
-from zipfile import ZipFile, ZIP_DEFLATED
-
 import datetime
 import glob
-import joblib
 import os
 import tempfile
 import types
 from shutil import rmtree
-from sklearn.base import BaseEstimator
+from zipfile import ZipFile, ZIP_DEFLATED
+
+import joblib
 from sklearn.model_selection import GridSearchCV
 
 from omegaml.backends.basemodel import BaseModelBackend
@@ -25,7 +24,9 @@ class ScikitLearnBackendV1(BaseModelBackend):
 
     @classmethod
     def supports(self, obj, name, **kwargs):
-        return isinstance(obj, BaseEstimator)
+        from sklearn.base import BaseEstimator
+        from sklearn.pipeline import Pipeline
+        return isinstance(obj, (BaseEstimator, Pipeline))
 
     # kept to support legacy scikit learn model serializations prior to ~scikit learn v0.18
     def _v1_package_model(self, model, filename):

--- a/omegaml/backends/tracking/base.py
+++ b/omegaml/backends/tracking/base.py
@@ -156,7 +156,7 @@ class TrackingProvider:
         Args:
             obj (str): the name of the model
             model_store (OmegaStore): the store to use, defaults to self._model_store
-            jobs_store (OmegaJobs): the jobs store to use, defaults to om.jobs
+            jobs_store (OmegaStore): the jobs store to use, defaults to om.jobs
 
         Returns:
             list of jobs created as [Metadata, ...]

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -121,6 +121,9 @@ OMEGA_STORE_BACKENDS = {
     'python.package': 'omegaml.backends.package.PythonPackageData',
     'pipsrc.package': 'omegaml.backends.package.PythonPipSourcedPackageData',
     'pandas.csv': 'omegaml.backends.externaldata.PandasExternalData',
+    'script.ipynb': 'omegaml.notebook.jobs.NotebookBackend',
+    # must be last backend listed as a catch-call
+    'core.object': 'omegaml.backends.coreobjects.CoreObjectsBackend',
 }
 OMEGA_STORE_BACKENDS_TENSORFLOW = {
     'tfkeras.h5': 'omegaml.backends.tensorflow.TensorflowKerasBackend',
@@ -175,6 +178,7 @@ OMEGA_STORE_MIXINS = [
     'omegaml.mixins.store.tracking.TrackableMetadataMixin',
     'omegaml.mixins.store.tracking.UntrackableMetadataMixin',
     'omegaml.mixins.store.objinfo.ObjectInformationMixin',
+    'omegaml.notebook.jobs.NotebookMixin',
 ]
 #: set hashed or clear names
 OMEGA_STORE_HASHEDNAMES = truefalse(os.environ.get('OMEGA_STORE_HASHEDNAMES', True))

--- a/omegaml/documents.py
+++ b/omegaml/documents.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import datetime
+
 from mongoengine.base.fields import ObjectIdField
 from mongoengine.document import Document
 from mongoengine.fields import (
@@ -26,10 +27,7 @@ class MDREGISTRY:
     MINIBATCH_STREAM = 'stream.minibatch'
 
     #: the list of accepted data types. extend using OmegaStore.register_backend
-    KINDS = [
-        PANDAS_DFROWS, PANDAS_SEROWS, PANDAS_HDF, PYTHON_DATA, SKLEARN_JOBLIB,
-        PANDAS_DFGROUP, OMEGAML_JOBS, OMEGAML_RUNNING_JOBS, SPARK_MLLIB, MINIBATCH_STREAM,
-    ]
+    KINDS = []
 
 
 class Metadata:
@@ -81,6 +79,7 @@ def make_Metadata(db_alias='omega', collection=None):
     # database from the given alias at the time of use
     from omegaml.documents import Metadata as Metadata_base
     collection = collection or settings().OMEGA_MONGO_COLLECTION
+
     class Metadata(Metadata_base, Document):
         # override db_alias in gridfile
         gridfile = FileField(

--- a/omegaml/notebook/omegacontentsmgr.py
+++ b/omegaml/notebook/omegacontentsmgr.py
@@ -1,15 +1,15 @@
-import mimetypes
-from base64 import encodebytes, decodebytes
-
 import json
-import nbformat
+import mimetypes
 import os
+from base64 import encodebytes, decodebytes
 from datetime import datetime
 from io import BytesIO
+from urllib.parse import unquote
+
+import nbformat
 from jupyter_server.services.contents.manager import ContentsManager
 from tornado import web
 from traitlets import default
-from urllib.parse import unquote
 
 from omegaml.notebook.checkpoints import NoOpCheckpoints
 
@@ -48,7 +48,7 @@ class OmegaStoreContentsManager(ContentsManager):
         """
         return the OmageStore for jobs (notebooks)
         """
-        return self.omega.jobs.store
+        return self.omega.jobs
 
     @property
     def _dir_placeholder(self):

--- a/omegaml/omega.py
+++ b/omegaml/omega.py
@@ -38,8 +38,6 @@ class Omega(CombinedStoreRequestCache, CombinedOmegaStoreMixin):
         :param celeryconf: the celery configuration dictionary
         """
         from omegaml.util import settings
-        # avoid circular imports
-        from omegaml.notebook.jobs import OmegaJobs
         # celery and mongo configuration
         self.defaults = defaults or settings()
         self.mongo_url = mongo_url or self.defaults.OMEGA_MONGO_URL
@@ -48,13 +46,12 @@ class Omega(CombinedStoreRequestCache, CombinedOmegaStoreMixin):
         self._dbalias = self._make_dbalias()
         self.models = self._make_store(prefix='models/')
         self.datasets = self._make_store(prefix='data/')
-        self._jobdata = self._make_store(prefix='jobs/')
+        self.jobs = self._make_store(prefix='jobs/')
         self.scripts = self._make_store(prefix='scripts/')
         # minibatch integration
         self.streams = self._make_streams(prefix='streams/')
         # runtimes environments
         self.runtime = self._make_runtime(celeryconf)
-        self.jobs = OmegaJobs(store=self._jobdata, defaults=self.defaults)
         # logger
         self.logger = OmegaSimpleLogger(store=self.datasets, defaults=self.defaults)
         # stores

--- a/omegaml/store/base.py
+++ b/omegaml/store/base.py
@@ -1,5 +1,4 @@
-"""
-Native storage for OmegaML using mongodb as the storage layer
+""" Native storage for OmegaML using mongodb as the storage layer
 
 An OmegaStore instance is a MongoDB database. It has at least the
 metadata collection which lists all objects stored in it. A metadata
@@ -76,36 +75,29 @@ from __future__ import absolute_import
 import logging
 import os
 import shutil
-import tempfile
 import warnings
 import weakref
-from datetime import datetime
 from uuid import uuid4
 
 import bson
 import gridfs
-from mongoengine.connection import disconnect, \
-    connect, _connections, get_db
+from mongoengine.connection import disconnect, connect, _connections, get_db
 from mongoengine.errors import DoesNotExist
-from mongoengine.fields import GridFSProxy
 from mongoengine.queryset.visitor import Q
 
-from omegaml.store.fastinsert import fast_insert, default_chunksize
-from omegaml.util import unravel_index, restore_index, make_tuple, jsonescape, \
-    cursor_to_dataframe, convert_dtypes, load_class, extend_instance, ensure_index, PickableCollection, \
-    mongo_compatible, signature
-from .queryops import sanitize_filter
-from ..documents import make_Metadata, MDREGISTRY
-from ..mongoshim import sanitize_mongo_kwargs, waitForConnection
-from ..util import (is_estimator, is_dataframe, is_ndarray, is_spark_mllib,
-                    settings as omega_settings, urlparse, is_series)
+from omegaml.documents import make_Metadata, MDREGISTRY
+from omegaml.mongoshim import sanitize_mongo_kwargs, waitForConnection
+from omegaml.util import load_class, extend_instance, ensure_index, PickableCollection, signature
+from omegaml.util import settings as omega_settings, urlparse
 
 logger = logging.getLogger(__name__)
 
 
 class OmegaStore(object):
-    """
-    The storage backend for models and data
+    """ The storage backend for models and data
+
+    .. versionchanged:: NEXT
+        refactored all methods handling Python and Pandas datatypes to omegaml.backends.coreobjects.CoreObjectsBackend
     """
 
     def __init__(self, mongo_url=None, bucket=None, prefix=None, kind=None, defaults=None, dbalias=None):
@@ -363,19 +355,34 @@ class OmegaStore(object):
         """
         register backends in defaults.OMEGA_STORE_BACKENDS
         """
-        for kind, backend in self.defaults.OMEGA_STORE_BACKENDS.items():
+        # enable list modification within loop
+        # -- avoid RuntimeError: dictionary changed size during iteration
+        backends = list(self.defaults.OMEGA_STORE_BACKENDS.items())
+        for kind, backend in backends:
             self.register_backend(kind, backend)
 
-    def register_backend(self, kind, backend):
+    def register_backend(self, kind, backend, index=-1):
         """
         register a backend class
 
         :param kind: (str) the backend kind
         :param backend: (class) the backend class
+        :param index: (int) the insert position, defaults to -1, which means
+          to append
+
+        .. versionchanged:: NEXT
+            added index to have more control over backend evaluation by .get_backend_byobj()
+
+        .. versionchanged:: NEXT
+            backends can specify cls.KIND_EXT to register additional kinds
         """
-        self.defaults.OMEGA_STORE_BACKENDS[kind] = load_class(backend)
-        if kind not in MDREGISTRY.KINDS:
-            MDREGISTRY.KINDS.append(kind)
+        backend_cls = load_class(backend)
+        backend_kinds = [backend_cls.KIND] + list(getattr(backend_cls, 'KIND_EXT', []))
+        for kind in backend_kinds:
+            self.defaults.OMEGA_STORE_BACKENDS[kind] = backend_cls
+            if kind not in MDREGISTRY.KINDS:
+                pos = len(MDREGISTRY.KINDS) + index if index < 0 else index
+                MDREGISTRY.KINDS.insert(pos, kind)
         return self
 
     def register_mixin(self, mixincls):
@@ -400,279 +407,7 @@ class OmegaStore(object):
                                          **kwargs)
         if backend:
             return backend.put(obj, name, attributes=attributes, **kwargs)
-        # TODO move all of the specifics to backend implementations
-        if is_estimator(obj):
-            backend = self.get_backend_bykind(MDREGISTRY.SKLEARN_JOBLIB)
-            return backend.put(obj, name, attributes=attributes, **kwargs)
-        elif is_spark_mllib(obj):
-            backend = self.get_backend_bykind(MDREGISTRY.SKLEARN_JOBLIB)
-            return backend.put(obj, name, attributes=attributes, **kwargs)
-        elif is_dataframe(obj) or is_series(obj):
-            groupby = kwargs.get('groupby')
-            if obj.empty:
-                from warnings import warn
-                warn(
-                    'Provided dataframe is empty, ignoring it, doing nothing here!')
-                return None
-            if kwargs.pop('as_hdf', False):
-                return self.put_dataframe_as_hdf(
-                    obj, name, attributes, **kwargs)
-            elif groupby:
-                return self.put_dataframe_as_dfgroup(
-                    obj, name, groupby, attributes)
-            append = kwargs.pop('append', None)
-            timestamp = kwargs.pop('timestamp', None)
-            index = kwargs.pop('index', None)
-            chunksize = kwargs.pop('chunksize', default_chunksize)
-            return self.put_dataframe_as_documents(
-                obj, name, append=append, attributes=attributes, index=index,
-                timestamp=timestamp, chunksize=chunksize, **kwargs)
-        elif is_ndarray(obj):
-            if kwargs.pop('as_pydata', False):
-                return self.put_pyobj_as_document(obj.tolist(), name,
-                                                  attributes=attributes, **kwargs)
-            return self.put_ndarray_as_hdf(obj, name, attributes=attributes,
-                                           **kwargs)
-        elif isinstance(obj, (dict, list, tuple)):
-            kwargs.pop('as_pydata', None)
-            if kwargs.pop('as_hdf', False):
-                return self.put_pyobj_as_hdf(obj, name,
-                                             attributes=attributes, **kwargs)
-            return self.put_pyobj_as_document(obj, name,
-                                              attributes=attributes,
-                                              **kwargs)
-        else:
-            raise TypeError('type %s not supported' % type(obj))
-
-    def put_dataframe_as_documents(self, obj, name, append=None,
-                                   attributes=None, index=None,
-                                   timestamp=None, chunksize=None,
-                                   ensure_compat=True, _fast_insert=fast_insert,
-                                   **kwargs):
-        """
-        store a dataframe as a row-wise collection of documents
-
-        :param obj: the dataframe to store
-        :param name: the name of the item in the store
-        :param append: if False collection will be dropped before inserting,
-           if True existing documents will persist. Defaults to True. If not
-           specified and rows have been previously inserted, will issue a
-           warning.
-        :param index: list of columns, using +, -, @ as a column prefix to
-           specify ASCENDING, DESCENDING, GEOSPHERE respectively. For @ the
-           column has to represent a valid GeoJSON object.
-        :param timestamp: if True or a field name adds a timestamp. If the
-           value is a boolean or datetime, uses _created as the field name.
-           The timestamp is always datetime.datetime.utcnow(). May be overriden
-           by specifying the tuple (col, datetime).
-        :param ensure_compat: if True attempt to convert obj to mongodb compatibility,
-           set to False only if you are sure to have only compatible values in dataframe.
-           defaults to True. False may reduce memory and increase speed on large dataframes.
-        :return: the Metadata object created
-        """
-        import pandas as pd
-        from .queryops import MongoQueryOps
-        collection = self.collection(name)
-        if is_series(obj):
-            import pandas as pd
-            obj = pd.DataFrame(obj, index=obj.index, columns=[str(obj.name)])
-            store_series = True
-        else:
-            store_series = False
-        if append is False:
-            self.drop(name, force=True)
-        elif append is None and collection.count_documents({}, limit=1):
-            from warnings import warn
-            warn('%s already exists, will append rows' % name)
-        if index:
-            # get index keys
-            if isinstance(index, dict):
-                idx_kwargs = index
-                index = index.pop('columns')
-            else:
-                idx_kwargs = {}
-            # create index with appropriate options
-            keys, idx_kwargs = MongoQueryOps().make_index(index, **idx_kwargs)
-            ensure_index(collection, keys, **idx_kwargs)
-        if timestamp:
-            dt = datetime.utcnow()
-            if isinstance(timestamp, bool):
-                col = '_created'
-            elif isinstance(timestamp, str):
-                col = timestamp
-            elif isinstance(timestamp, datetime):
-                col, dt = '_created', timestamp
-            elif isinstance(timestamp, tuple):
-                col, dt = timestamp
-            else:
-                col = '_created'
-            obj[col] = dt
-        # store dataframe indicies
-        # FIXME this may be a performance issue, use size stored on stats or metadata
-        row_count = self.collection(name).estimated_document_count()
-        # fixes #466, ensure column names are strings in a multiindex
-        if isinstance(obj.columns, pd.MultiIndex):
-            obj.columns = obj.columns.map('_'.join)
-        obj, idx_meta = unravel_index(obj, row_count=row_count)
-        stored_columns = [jsonescape(col) for col in obj.columns]
-        column_map = list(zip(obj.columns, stored_columns))
-        d_column_map = dict(column_map)
-        dtypes = {
-            d_column_map.get(k): v.name
-            for k, v in obj.dtypes.items()
-        }
-        kind_meta = {
-            'columns': column_map,
-            'dtypes': dtypes,
-            'idx_meta': idx_meta
-        }
-        # ensure column names to be strings
-        obj.columns = stored_columns
-        # create mongon indicies for data frame index columns
-        df_idxcols = [col for col in obj.columns if col.startswith('_idx#')]
-        if df_idxcols:
-            keys, idx_kwargs = MongoQueryOps().make_index(df_idxcols)
-            ensure_index(collection, keys, **idx_kwargs)
-        # create index on row id
-        keys, idx_kwargs = MongoQueryOps().make_index(['_om#rowid'])
-        ensure_index(collection, keys, **idx_kwargs)
-        # bulk insert
-        # -- get native objects
-        # -- seems to be required since pymongo 3.3.x. if not converted
-        #    pymongo raises Cannot Encode object for int64 types
-        if ensure_compat:
-            for col, col_dtype in dtypes.items():
-                if 'datetime' in col_dtype:
-                    obj[col].fillna('', inplace=True)
-        obj = obj.astype('O', errors='ignore')
-        _fast_insert(obj, self, name, chunksize=chunksize)
-        kind = (MDREGISTRY.PANDAS_SEROWS
-                if store_series
-                else MDREGISTRY.PANDAS_DFROWS)
-        meta = self._make_metadata(name=name,
-                                   prefix=self.prefix,
-                                   bucket=self.bucket,
-                                   kind=kind,
-                                   kind_meta=kind_meta,
-                                   attributes=attributes,
-                                   collection=collection.name)
-        return meta.save()
-
-    def put_dataframe_as_dfgroup(self, obj, name, groupby, attributes=None):
-        """
-        store a dataframe grouped by columns in a mongo document
-
-        :Example:
-
-          > # each group
-          >  {
-          >     #group keys
-          >     key: val,
-          >     _data: [
-          >      # only data keys
-          >        { key: val, ... }
-          >     ]}
-
-        """
-
-        def row_to_doc(obj):
-            for gval, gdf in obj.groupby(groupby):
-                if hasattr(gval, 'astype'):
-                    gval = make_tuple(gval.astype('O'))
-                else:
-                    gval = make_tuple(gval)
-                doc = dict(zip(groupby, gval))
-                datacols = list(set(gdf.columns) - set(groupby))
-                doc['_data'] = gdf[datacols].astype('O').to_dict('records')
-                yield doc
-
-        datastore = self.collection(name)
-        datastore.drop()
-        datastore.insert_many(row_to_doc(obj))
-        return self._make_metadata(name=name,
-                                   prefix=self.prefix,
-                                   bucket=self.bucket,
-                                   kind=MDREGISTRY.PANDAS_DFGROUP,
-                                   attributes=attributes,
-                                   collection=datastore.name).save()
-
-    def put_dataframe_as_hdf(self, obj, name, attributes=None, **kwargs):
-        filename = self.object_store_key(name, '.hdf')
-        hdffname = self._package_dataframe2hdf(obj, filename)
-        with open(hdffname, 'rb') as fhdf:
-            fileid = self.fs.put(fhdf, filename=filename)
-        return self._make_metadata(name=name,
-                                   prefix=self.prefix,
-                                   bucket=self.bucket,
-                                   kind=MDREGISTRY.PANDAS_HDF,
-                                   attributes=attributes,
-                                   gridfile=GridFSProxy(db_alias=self._dbalias,
-                                                        grid_id=fileid)).save()
-
-    def put_ndarray_as_hdf(self, obj, name, attributes=None, **kwargs):
-        """ store numpy array as hdf
-
-        this is hack, converting the array to a dataframe then storing
-        it
-        """
-        import pandas as pd
-        df = pd.DataFrame(obj)
-        return self.put_dataframe_as_hdf(df, name, attributes=attributes)
-
-    def put_pyobj_as_hdf(self, obj, name, attributes=None, **kwargs):
-        """
-        store list, tuple, dict as hdf
-
-        this requires the list, tuple or dict to be convertible into
-        a dataframe
-        """
-        import pandas as pd
-        df = pd.DataFrame(obj)
-        return self.put_dataframe_as_hdf(df, name, attributes=attributes)
-
-    def put_pyobj_as_document(self, obj, name, attributes=None, append=True, index=None, as_many=None, **kwargs):
-        """
-        store a dict as a document
-
-        similar to put_dataframe_as_documents no data will be replaced by
-        default. that is, obj is appended as new documents into the objects'
-        mongo collection. to replace the data, specify append=False.
-        """
-        collection = self.collection(name)
-        if append is False:
-            collection.drop()
-        elif append is None and collection.esimated_document_count(limit=1):
-            from warnings import warn
-            warn('%s already exists, will append rows' % name)
-        if index:
-            # create index with appropriate options
-            from omegaml.store import MongoQueryOps
-            if isinstance(index, dict):
-                idx_kwargs = index
-                index = index.pop('columns')
-            else:
-                idx_kwargs = {}
-            index = [f'data.{c}' for c in index]
-            keys, idx_kwargs = MongoQueryOps().make_index(index, **idx_kwargs)
-            ensure_index(collection, keys, **idx_kwargs)
-        if as_many is None:
-            as_many = isinstance(obj, (list, tuple)) and isinstance(obj[0], (list, tuple))
-        if as_many:
-            # list of lists are inserted as many objects, as in pymongo < 4
-            records = (mongo_compatible({'data': item}) for item in obj)
-            result = collection.insert_many(records)
-            objid = result.inserted_ids[-1]
-        else:
-            result = collection.insert_one(mongo_compatible({'data': obj}))
-            objid = result.inserted_id
-
-        return self._make_metadata(name=name,
-                                   prefix=self.prefix,
-                                   bucket=self.bucket,
-                                   kind=MDREGISTRY.PYTHON_DATA,
-                                   collection=collection.name,
-                                   attributes=attributes,
-                                   objid=objid).save()
+        raise TypeError('type %s not supported' % type(obj))
 
     def drop(self, name, force=False, version=-1, report=False, **kwargs):
         """
@@ -807,7 +542,7 @@ class OmegaStore(object):
         else:
             backend = self.get_backend(name_or_obj) or self.get_backend_byobj(name_or_obj)
         if backend is None:
-            backend = self
+            backend = self.get_backend_bykind('core.object', model_store=self, data_store=self)
         if not raw and meta is not None and 'docs' in meta.attributes:
             def UserDocumentation():
                 pass
@@ -825,6 +560,9 @@ class OmegaStore(object):
 
         Returns:
             the first backend that supports the given parameters or None
+
+        .. versionchanged:: NEXT
+            backends are tested in order of MDREGISTRY.KINDS, see .register_backend()
         """
         model_store = model_store or self
         data_store = data_store or self
@@ -832,7 +570,6 @@ class OmegaStore(object):
         kind = kind or (meta.kind if meta is not None else None)
         backend = None
         if kind:
-            objtype = str(type(obj))
             if kind in self.defaults.OMEGA_STORE_BACKENDS:
                 backend = self.get_backend_bykind(kind, data_store=data_store, model_store=model_store)
                 if not backend.supports(obj, name, attributes=attributes,
@@ -840,13 +577,15 @@ class OmegaStore(object):
                                         model_store=model_store,
                                         meta=meta,
                                         kind=kind, **kwargs):
+                    objtype = str(type(obj))
                     warnings.warn('Backend {kind} does not support {objtype}'.format(**locals()))
             else:
-                pass
-                # TODO refactor pandas and numpy handling into proper backend to avoid misleading warning
-                # warnings.warn('Backend {kind} not found {objtype}. Reverting to default'.format(**locals()))
+                # revert to core backend
+                backend = self.get_backend_bykind('core.object', model_store=model_store, data_store=data_store)
         else:
-            for backend_kind, backend_cls in self.defaults.OMEGA_STORE_BACKENDS.items():
+            # sort by order in MDREGISTRY.KINDS, only using kinds that actually have a registered backend
+            sorted_backends = (k for k in MDREGISTRY.KINDS if k in self.defaults.OMEGA_STORE_BACKENDS)
+            for backend_kind in sorted_backends:
                 backend = self.get_backend_bykind(backend_kind, data_store=data_store, model_store=model_store)
                 if backend.supports(obj, name, attributes=attributes,
                                     data_store=data_store, model_store=model_store,
@@ -882,224 +621,16 @@ class OmegaStore(object):
         if not force_python:
             backend = (self.get_backend(name, model_store=model_store,
                                         data_store=data_store)
-                       if not kind else self.get_backend_bykind(kind,
-                                                                model_store=model_store,
-                                                                data_store=data_store))
+                       if not kind else self.get_backend_bykind(kind, model_store=model_store, data_store=data_store))
             if backend is not None:
                 # FIXME: some backends need to get model_store, data_store, but fails tests
                 return backend.get(name, **kwargs)  # model_store=model_store, data_store=data_store, **kwargs)
-            if meta.kind == MDREGISTRY.SKLEARN_JOBLIB:
-                backend = self.get_backend(name)
-                return backend.get_model(name)
-            elif meta.kind == MDREGISTRY.SPARK_MLLIB:
-                backend = self.get_backend(name)
-                return backend.get_model(name, version)
-            elif meta.kind == MDREGISTRY.PANDAS_DFROWS:
-                return self.get_dataframe_documents(name, version=version,
-                                                    **kwargs)
-            elif meta.kind == MDREGISTRY.PANDAS_SEROWS:
-                return self.get_dataframe_documents(name, version=version,
-                                                    is_series=True,
-                                                    **kwargs)
-            elif meta.kind == MDREGISTRY.PANDAS_DFGROUP:
-                return self.get_dataframe_dfgroup(
-                    name, version=version, **kwargs)
-            elif meta.kind == MDREGISTRY.PYTHON_DATA:
-                return self.get_python_data(name, version=version, **kwargs)
-            elif meta.kind == MDREGISTRY.PANDAS_HDF:
-                return self.get_dataframe_hdf(name, version=version)
-        return self.get_object_as_python(meta, version=version)
-
-    def get_dataframe_documents(self, name, columns=None, lazy=False,
-                                filter=None, version=-1, is_series=False,
-                                chunksize=None, sanitize=True, trusted=None,
-                                **kwargs):
-        """
-        Internal method to return DataFrame from documents
-
-        :param name: the name of the object (str)
-        :param columns: the column projection as a list of column names
-        :param lazy: if True returns a lazy representation as an MDataFrame.
-           If False retrieves all data and returns a DataFrame (default)
-        :param filter: the filter to be applied as a column__op=value dict
-        :param sanitize: sanitize filter by removing all $op filter keys,
-          defaults to True. Specify False to allow $op filter keys. $where
-          is always removed as it is considered unsafe.
-        :param version: the version to retrieve (not supported)
-        :param is_series: if True retruns a Series instead of a DataFrame
-        :param kwargs: remaining kwargs are used a filter. The filter kwarg
-           overrides other kwargs.
-        :return: the retrieved object (DataFrame, Series or MDataFrame)
-
-        """
-        from omegaml.store.queryops import sanitize_filter
-        from omegaml.store.filtered import FilteredCollection
-
-        collection = self.collection(name)
-        meta = self.metadata(name)
-        filter = filter or kwargs
-        filter = sanitize_filter(filter, no_ops=sanitize, trusted=trusted)
-        if lazy or chunksize:
-            from ..mdataframe import MDataFrame
-            df = MDataFrame(collection,
-                            metadata=meta.kind_meta,
-                            columns=columns).query(**filter)
-            if is_series:
-                df = df[0]
-            if chunksize is not None and chunksize > 0:
-                return df.iterchunks(chunksize=chunksize)
-        else:
-            # TODO ensure the same processing is applied in MDataFrame
-            # TODO this method should always use a MDataFrame disregarding lazy
-            if filter:
-                from .query import Filter
-                query = Filter(collection, **filter).query
-                cursor = FilteredCollection(collection).find(filter=query, projection=columns)
-            else:
-                cursor = FilteredCollection(collection).find(projection=columns)
-            # restore dataframe
-            df = cursor_to_dataframe(cursor)
-            if '_id' in df.columns:
-                del df['_id']
-            if hasattr(meta, 'kind_meta'):
-                df = convert_dtypes(df, meta.kind_meta.get('dtypes', {}))
-            # -- restore columns
-            meta_columns = dict(meta.kind_meta.get('columns'))
-            if meta_columns:
-                # apply projection, if any
-                if columns:
-                    # get only projected columns
-                    # meta_columns is {origin_column: stored_column}
-                    orig_columns = dict({k: v for k, v in meta_columns.items()
-                                         if k in columns or v in columns})
-                else:
-                    # restore columns to original name
-                    orig_columns = meta_columns
-                df.rename(columns=orig_columns, inplace=True)
-            # -- restore indexes
-            idx_meta = meta.kind_meta.get('idx_meta')
-            if idx_meta:
-                df = restore_index(df, idx_meta)
-            # -- restore row order
-            if is_series:
-                index = df.index
-                name = df.columns[0]
-                df = df[name]
-                df.index = index
-                df.name = None if name == 'None' else name
-        return df
-
-    def rebuild_params(self, kwargs, collection):
-        """
-        Returns a modified set of parameters for querying mongodb
-        based on how the mongo document is structured and the
-        fields the document is grouped by.
-
-        **Note: Explicitly to be used with get_grouped_data only**
-
-        :param kwargs: Mongo filter arguments
-        :param collection: The name of mongodb collection
-        :return: Returns a set of parameters as dictionary.
-        """
-        modified_params = {}
-        db_structure = collection.find_one({}, {'_id': False})
-        groupby_columns = list(set(db_structure.keys()) - set(['_data']))
-        if kwargs is not None:
-            for item in kwargs:
-                if item not in groupby_columns:
-                    modified_query_param = '_data.' + item
-                    modified_params[modified_query_param] = kwargs.get(item)
-                else:
-                    modified_params[item] = kwargs.get(item)
-        return modified_params
-
-    def get_dataframe_dfgroup(self, name, version=-1, sanitize=True, kwargs=None):
-        """
-        Return a grouped dataframe
-
-        :param name: the name of the object
-        :param version: not supported
-        :param kwargs: mongo db query arguments to be passed to
-               collection.find() as a filter.
-        :param sanitize: remove any $op operators in kwargs
-
-        """
-        import pandas as pd
-        from omegaml.store.queryops import sanitize_filter
-        from omegaml.store.filtered import FilteredCollection
-
-        def convert_doc_to_row(cursor):
-            for doc in cursor:
-                data = doc.pop('_data', [])
-                for row in data:
-                    doc.update(row)
-                    yield doc
-
-        datastore = FilteredCollection(self.collection(name))
-        kwargs = kwargs if kwargs else {}
-        params = self.rebuild_params(kwargs, datastore)
-        params = sanitize_filter(params, no_ops=sanitize)
-        cursor = datastore.find(params, projection={'_id': False})
-        df = pd.DataFrame(convert_doc_to_row(cursor))
-        return df
-
-    def get_dataframe_hdf(self, name, version=-1):
-        """
-        Retrieve dataframe from hdf
-
-        :param name: The name of object
-        :param version: The version of object (not supported)
-        :return: Returns a python pandas dataframe
-        :raises: gridfs.errors.NoFile
-        """
-        df = None
-        meta = self.metadata(name)
-        filename = getattr(meta.gridfile, 'name', self.object_store_key(name, '.hdf'))
-        if self.fs.exists(filename=filename):
-            df = self._extract_dataframe_hdf(filename, version=version)
-            return df
-        else:
-            raise gridfs.errors.NoFile(
-                "{0} does not exist in mongo collection '{1}'".format(
-                    name, self.bucket))
-
-    def get_python_data(self, name, filter=None, version=-1, lazy=False, trusted=False, **kwargs):
-        """
-        Retrieve objects as python data
-
-        :param name: The name of object
-        :param version: The version of object
-
-        :return: Returns the object as python list object
-        """
-        datastore = self.collection(name)
-        filter = filter or kwargs
-        sanitize_filter(filter) if trusted is False or trusted != signature(filter) else filter
-        cursor = datastore.find(filter, **kwargs)
-        if lazy:
-            return cursor
-        data = (d.get('data') for d in cursor)
-        return list(data)
-
-    def get_object_as_python(self, meta, version=-1):
-        """
-        Retrieve object as python object
-
-        :param meta: The metadata object
-        :param version: The version of the object
-
-        :return: Returns data as python object
-        """
-        if meta.kind == MDREGISTRY.SKLEARN_JOBLIB:
-            return meta.gridfile
-        if meta.kind == MDREGISTRY.PANDAS_HDF:
-            return meta.gridfile
-        if meta.kind == MDREGISTRY.PANDAS_DFROWS:
-            return list(getattr(self.mongodb, meta.collection).find())
-        if meta.kind == MDREGISTRY.PYTHON_DATA:
-            col = getattr(self.mongodb, meta.collection)
-            return col.find_one(dict(_id=meta.objid)).get('data')
-        raise TypeError('cannot return kind %s as a python object' % meta.kind)
+        # catch-call to CoreObjectsBackend or force python
+        # -- keeping the same behavior until version 0.17, handling all other KINDs
+        core_backend = self.get_backend_bykind('core.object', model_store=model_store, data_store=data_store)
+        if force_python:
+            return core_backend.get_object_as_python(meta, version=version)
+        return core_backend.get(name, version=version, force_python=force_python, **kwargs)
 
     def __iter__(self):
         for f in self.list(include_temp=True):
@@ -1205,48 +736,6 @@ class OmegaStore(object):
             name=name,
             ext=ext).replace('/', '_').replace('..', '.')
         return filename
-
-    def _package_dataframe2hdf(self, df, filename, key=None):
-        """
-        Package a dataframe as a hdf file
-
-        :param df: The dataframe
-        :param filename: Name of file
-
-        :return: Filename of hdf file
-        """
-        lpath = tempfile.mkdtemp()
-        fname = os.path.basename(filename)
-        hdffname = os.path.join(self.tmppath, fname + '.hdf')
-        key = key or 'data'
-        df.to_hdf(hdffname, key)
-        return hdffname
-
-    def _extract_dataframe_hdf(self, filename, version=-1):
-        """
-        Extracts a dataframe from a stored hdf file
-
-        :param filename: The name of file
-        :param version: The version of file
-
-        :return: Pandas dataframe
-        """
-        import pandas as pd
-        hdffname = os.path.join(self.tmppath, filename)
-        dirname = os.path.dirname(hdffname)
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
-        try:
-            outf = self.fs.get_version(filename, version=version)
-        except gridfs.errors.NoFile as e:
-            raise e
-        with open(hdffname, 'wb') as hdff:
-            hdff.write(outf.read())
-        hdf = pd.HDFStore(hdffname)
-        key = list(hdf.keys())[0]
-        df = hdf[key]
-        hdf.close()
-        return df
 
     def _ensure_fs_collection(self):
         # ensure backwards-compatible gridfs access

--- a/omegaml/store/streams.py
+++ b/omegaml/store/streams.py
@@ -1,7 +1,7 @@
 import warnings
 from hashlib import md5
-from mongoengine import DoesNotExist
 
+from omegaml.documents import MDREGISTRY
 from omegaml.store import OmegaStore
 
 
@@ -43,6 +43,8 @@ class StreamsProxy(OmegaStore):
         minibatch package for details
     """
 
+    KIND = 'stream.minibatch'
+
     # TODO move this implementation to a proper OmegaStore backend or mixin
     # this is a OmegaStore so we can have Metadata support
     # it is called the StreamsProxy because it behaves more like a Mixin
@@ -63,7 +65,8 @@ class StreamsProxy(OmegaStore):
     def register_backends(self):
         # TODO enable custom backends
         # disabled to avoid interference with custom get(), put()
-        pass
+        if self.KIND not in MDREGISTRY.KINDS:
+            MDREGISTRY.KINDS.append(self.KIND)
 
     def _qualified_stream(self, name, *args, **kwargs):
         return f'{self.bucket}.{self.prefix}.{name}.stream'
@@ -141,7 +144,7 @@ class StreamsProxy(OmegaStore):
             }
         }
         meta = self.make_metadata(name,
-                                  'stream.minibatch',
+                                  self.KIND,
                                   prefix=self.prefix,
                                   bucket=self.bucket,
                                   kind_meta=kind_meta).save()

--- a/omegaml/tests/core/test_backendbase.py
+++ b/omegaml/tests/core/test_backendbase.py
@@ -1,19 +1,24 @@
 from unittest.case import TestCase
 
 import omegaml as om
+from omegaml.backends.basedata import BaseDataBackend
 from omegaml.backends.basemodel import BaseModelBackend
 from omegaml.documents import MDREGISTRY
-from omegaml.backends.basedata import BaseDataBackend
+from omegaml.tests.util import OmegaTestMixin
 
 
-class CustomBackendTests(TestCase):
-
+class CustomBackendTests(OmegaTestMixin, TestCase):
     """
     Test custom backends with new kinds
 
     Note we are not implemented actually working backends. What we're
     interested here is that the backend API and Metadata storage work.
     """
+
+    def setUp(self):
+        self.om = om.Omega()
+        self.clean()
+
     def tearDown(self):
         # remove custom backend from implementation not to disturb other tests
         try:
@@ -28,7 +33,7 @@ class CustomBackendTests(TestCase):
         """
         test custom model type
         """
-        om.models.register_backend('custom.foo', CustomModelBackend)
+        om.models.register_backend(CustomModelBackend.KIND, CustomModelBackend, index=0)
         foo = dict(foo='bar')
         meta = om.models.put(foo, 'footest')
         self.assertIsInstance(meta, om.models._Metadata)
@@ -43,7 +48,7 @@ class CustomBackendTests(TestCase):
         """
         test custom dataset type
         """
-        om.datasets.register_backend('custom.bar', CustomDataBackend)
+        om.datasets.register_backend(CustomDataBackend.KIND, CustomDataBackend, index=0)
         foo = dict(bar='foo')
         meta = om.datasets.put(foo, 'bartest')
         self.assertIsInstance(meta, om.datasets._Metadata)
@@ -56,7 +61,6 @@ class CustomBackendTests(TestCase):
 
 
 class CustomModelBackend(BaseModelBackend):
-
     """
     Minimalist model backend
     """
@@ -66,11 +70,12 @@ class CustomModelBackend(BaseModelBackend):
     def supports(self, obj, name, **kwargs):
         return isinstance(obj, dict) and 'foo' in obj
 
-class CustomDataBackend(BaseDataBackend):
 
+class CustomDataBackend(BaseDataBackend):
     """
     Minimalist dataset backend
     """
+    KIND = 'custom.bar'
 
     @classmethod
     def supports(self, obj, name, **kwargs):

--- a/omegaml/tests/core/test_imexport.py
+++ b/omegaml/tests/core/test_imexport.py
@@ -1,12 +1,13 @@
 import os
-import pandas as pd
 import sys
 import unittest
-from pandas._testing import assert_frame_equal
 from pathlib import Path
-from sklearn.linear_model import LinearRegression
 from types import ModuleType
 from unittest.mock import patch
+
+import pandas as pd
+from pandas._testing import assert_frame_equal
+from sklearn.linear_model import LinearRegression
 
 from omegaml import Omega
 from omegaml.mixins.store.imexport import ObjectImportExportMixin, OmegaExportArchive, OmegaExporter
@@ -25,7 +26,7 @@ class ImportExportMixinTests(OmegaTestMixin, unittest.TestCase):
             arc.clear()
 
     def _apply_store_mixin(self, omx):
-        for store in (omx.datasets, omx.models, omx.jobs.store, omx.scripts, omx.streams):
+        for store in (omx.datasets, omx.models, omx.jobs, omx.scripts, omx.streams):
             store.register_mixin(ObjectImportExportMixin)
 
     def test_dataframe_export(self):
@@ -278,7 +279,6 @@ class ImportExportMixinTests(OmegaTestMixin, unittest.TestCase):
             # check jobs were not restored yet
             self.assertEqual(om_restore.jobs.list(), [])
             # restore jobs explicitly
-            # -- note jobs promotion is not supported (pending #218)
             OmegaExporter(om_restore).from_archive('/tmp/test',
                                                    pattern='jobs/.*')
             self.assertEqual(om_restore.jobs.list(), ['myjob.ipynb'])

--- a/omegaml/tests/core/test_jobs.py
+++ b/omegaml/tests/core/test_jobs.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import
 
-from unittest import TestCase, skip
-
-import gridfs
 import os
 from datetime import timedelta
+from unittest import TestCase, skip
+
 from nbformat import v4
 
 from omegaml import Omega
@@ -249,7 +248,7 @@ class JobTests(TestCase):
     def test_run_nonexistent_job(self):
         om = self.om
         self.assertRaises(
-            gridfs.errors.NoFile, om.jobs.run_notebook, 'dummys.ipynb')
+            AssertionError, om.jobs.run_notebook, 'dummys.ipynb')
 
     def test_scheduled_job_with_omegaml_block(self):
         om = self.om

--- a/omegaml/tests/core/test_npndarray.py
+++ b/omegaml/tests/core/test_npndarray.py
@@ -1,13 +1,15 @@
 from unittest import TestCase
 
-from omegaml import Omega
-from omegaml.backends.npndarray import NumpyNDArrayBackend
-
 import numpy as np
 
+from omegaml import Omega
+from omegaml.backends.npndarray import NumpyNDArrayBackend
+from omegaml.tests.util import OmegaTestMixin
 
-class NumpyNDArrayBackendTests(TestCase):
+
+class NumpyNDArrayBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
+        super().setUp()
         om = self.om = Omega()
         om.datasets.register_backend(NumpyNDArrayBackend.KIND, NumpyNDArrayBackend)
 

--- a/omegaml/tests/streams/test_streams.py
+++ b/omegaml/tests/streams/test_streams.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-
 from unittest.mock import patch, MagicMock
 
 from omegaml import Omega
@@ -108,13 +107,16 @@ class StreamsTestCase(OmegaTestMixin, TestCase):
 
     def test_streams_attach_runtime(self):
         om = self.om
+        # no dataset
         with self.assertRaises(ValueError):
             om.streams.get('test', source='foobar')
         # test we can attach to a dataset
         om.datasets.put([1, 2, 3], 'foobar')
         stream = om.streams.get('test', source='foobar')
         om.datasets.put([1, 2, 3], 'foobar')
-        self.assertEqual(len(list(stream.buffer())), 1)
+        # allow some time for the stream to append
+        # sleep(1)
+        self.assertGreaterEqual(len(list(stream.buffer())), 1)
         stream.stop()
         stream.clear()
         # test we can attach to the runtime

--- a/omegaml/tests/util.py
+++ b/omegaml/tests/util.py
@@ -1,9 +1,8 @@
-from http import HTTPStatus
-
 import logging
 import os
 import sys
 import warnings
+from http import HTTPStatus
 
 from omegaml import Omega
 from omegaml.client.lunamon import LunaMonitor
@@ -42,7 +41,7 @@ class OmegaTestMixin(object):
                   **drop_kwargs) for m in part.list(hidden=True, include_temp=True, raw=True)]
             # ignore system members, as they may get recreated e.g. by LunaMonitor
             existing = [m.name for m in part.list(hidden=True, include_temp=True, raw=True)
-                        if not '.system' in m.name.startswith()]
+                        if not '.system' in m.name]
             self.assertListEqual(existing, [])
 
     @property

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -60,32 +60,12 @@ def is_series(obj):
         return False
 
 
-def is_estimator(obj):
-    try:
-        from sklearn.base import BaseEstimator
-        from sklearn.pipeline import Pipeline
-        return isinstance(obj, (BaseEstimator, Pipeline))
-    except:
-        False
-
-
 def is_ndarray(obj):
     try:
         import numpy as np
         return isinstance(obj, np.ndarray)
     except:
         False
-
-
-def is_spark_mllib(obj):
-    """
-    # unlike scikit learn obj is not the actual model, but a specification of
-    # the model for the spark server to create. so obj is the name of the
-    # python class, e.g. obj=pyspark.mllib.clustering.KMeans
-    """
-    if isinstance(obj, str):
-        return 'pyspark.mllib' in obj
-    return False
 
 
 def settings(reload=False):


### PR DESCRIPTION
- provide CoreObjectsBackend to handle basic Python and Pandas data types
- remove built-in mllib support, keeping SparkBackend for reference (ee only)
- simplify base.OmegaStore implementation, delegating all storage to backends (other than Metadata)
- refactor MDREGISTY.KINDS to be empty by default, accepting only dynamically registered backends
- refactor OmegaJobs as a backend
- closes #218 