### PR TITLE
feat: add dynamic backends implemented as virtualobj helper functions

### DIFF
--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -180,6 +180,7 @@ OMEGA_STORE_MIXINS = [
     'omegaml.mixins.store.tracking.UntrackableMetadataMixin',
     'omegaml.mixins.store.objinfo.ObjectInformationMixin',
     'omegaml.notebook.jobs.NotebookMixin',
+    'omegaml.mixins.store.objhelper.ObjectHelperMixin',
 ]
 #: set hashed or clear names
 OMEGA_STORE_HASHEDNAMES = truefalse(os.environ.get('OMEGA_STORE_HASHEDNAMES', True))

--- a/omegaml/mixins/store/objhelper.py
+++ b/omegaml/mixins/store/objhelper.py
@@ -1,0 +1,175 @@
+import re
+from inspect import isclass
+
+from omegaml.backends.virtualobj import VirtualObjectBackend
+
+
+class VirtualHelperBackend(VirtualObjectBackend):
+    KIND = 'virtualobj.helper'
+
+    def __init__(self, handler, store, model_store=None, data_store=None, tracking=None, backend=None, **kwargs):
+        super().__init__(model_store=model_store, data_store=data_store, tracking=tracking, **kwargs)
+        self.handler = handler  # the handler fn (virtualobj)
+        self.store = store  # the store where we're at
+        self.backend = backend  # the original backend
+
+    def get(self, name, **kwargs):
+        meta = self.store.metadata(name)
+        data = self.handler(method='get', obj=None, name=name, meta=meta, store=self.store, backend=self.backend,
+                            **kwargs)
+        return data or self.backend.get(name, **kwargs)
+
+    def put(self, obj, name, **kwargs):
+        meta = self.store.metadata(name)
+        handled_meta = self.handler(method='put', obj=obj, name=name, meta=meta, store=self.store, backend=self.backend,
+                                    **kwargs)
+        meta = handled_meta or self.backend.put(obj, name, **kwargs)
+        meta.kind_meta.setdefault('helper', self.handler._handler_name)
+        meta.save()
+        return meta
+
+    def drop(self, name, force=False, **kwargs):
+        meta = self.store.metadata(name)
+        result = self.handler(method='put', obj=name, meta=meta, force=force, **kwargs)
+        return self.backend.drop(name, force=force, **kwargs) if result is None else result
+
+    def predict(self, modelname, Xname=None, Yname=None, **kwargs):
+        meta = self.store.metadata(modelname)
+        model = self.get(modelname, **kwargs)
+        data = self.data_store.get(Xname)
+        result = self.handler(method='predict', obj=model, name=modelname, meta=meta, store=self.store,
+                              backend=self.backend, data=data, **kwargs)
+        return result
+
+
+class ObjectHelperMixin:
+    """ virtual backend support
+
+    Enables the use of any virtualobj as a dynamically loaded backend
+
+    Usage:
+        A helper is a virtualobj that handles .get(), .put(), .drop() for an object, overriding or extending
+        the actual backend responsible for handling objects of that kind. Unlike actual backends, helpers
+        can be created, stored and deployed at runtime.::
+
+            @virtualobj
+            def myhelper(*args, method=None, obj=None, meta=None, store=None, backend=None, **kwargs):
+                if method == 'get':
+                    obj = ...
+                    return obj
+                if method == 'put':
+                    save(obj)
+                    return store.make_metadata(...)
+
+            # store this helper
+            om.models.put(myhelper, 'helpers/myhelper')
+
+            # store some model using this helper, e.g. to support a new serialization format
+            obj = Model(...)
+            om.models.put(obj, 'mymodel', helper='helpers/myhelper')
+
+        We can specify helpers to be automatically used for certain object types by adding
+        the ``supports='<kind>|<type>[,...]'`` keyword.::
+
+            om.models.put(myhelper, 'helpers/myhelper', supports='sklearn.*')
+
+        This ensures 'helpers/myhelpers' is selected automatically to handle objects whose type is part
+        of the sklearn library.
+
+            # the .put() call will be handled by helper/myhelper
+            model = sklearn.linear_model.LinearRegression()
+            om.models.put(model, 'mymodel')
+
+    .. versionadded:: NEXT
+        add dynamic backends implemented as virtualobjects
+    """
+
+    def put(self, obj, name, supports=None, **kwargs):
+        """ store a virtualobj as a helper for other objects
+
+        Args:
+            obj (any): any object supported by backends
+            name (str): the name of the object
+            supports (str): a support specification of the format ``<kind>|<module.name>[,...]``
+            **kwargs: passed on to backend handling type(obj)
+
+        Returns:
+            Metadata
+        """
+        meta = super().put(obj, name, **kwargs)
+        if supports:
+            meta_helpers = self.put({}, '.helpers')
+            all_supports = meta_helpers.attributes.setdefault('supports', {})
+            all_supports[name] = supports
+            meta_helpers.save()
+        return meta
+
+    def get_backend(self, name, model_store=None, data_store=None, helper=None, **kwargs):
+        meta = self.metadata(name)
+        if meta:
+            backend = super().get_backend(name, model_store=model_store, data_store=data_store, **kwargs)
+            helper = None if helper is False else (
+                    helper or meta.kind_meta.get('helper') or self._resolve_supports(meta=meta))
+            if helper:
+                return self._get_handler(helper, model_store, data_store, backend, **kwargs)
+        return super().get_backend(name, model_store=model_store, data_store=data_store, **kwargs)
+
+    def get_backend_byobj(self, obj, name=None, model_store=None, data_store=None, helper=None, **kwargs):
+        meta = self.metadata(name) if name else None
+        backend = super().get_backend_byobj(obj, name, model_store=model_store, data_store=data_store, **kwargs)
+        kind = getattr(backend, 'KIND', '__nobackend__')
+        helper = helper or (meta.kind_meta.get('helper') if meta is not None else None) or self._resolve_supports(
+            obj=obj, meta=meta, kind=kind)
+        if helper:
+            return self._get_handler(helper, model_store, data_store, backend)
+        return backend
+
+    def _get_handler(self, helper, model_store, data_store, backend, **kwargs):
+        handler = self.get(helper, raw=True)
+        handler._handler_name = helper
+        model_store = model_store or self
+        data_store = data_store or self
+        return VirtualHelperBackend(handler, self, model_store=model_store, data_store=data_store,
+                                    backend=backend, **kwargs)
+
+    def _resolve_supports(self, obj=None, meta=None, kind=None):
+        helpers_meta = self.metadata('.helpers')
+        if not helpers_meta:
+            return
+        supports = helpers_meta.attributes.get('supports', {})
+        default_ref = 'obj' if obj is not None else 'kind'
+        obj_kind = (meta.kind if meta else kind) or '__nobackend__'
+        obj_fqn = fully_qualified_name(obj)
+        for helper, spec in supports.items():
+            for parts in spec.split(','):
+                ref, tspec = parts.split(':', 1) if ':' in spec else (default_ref, parts)
+                match_kind = ref == 'kind' and re.match(tspec, obj_kind)
+                match_obj = ref == 'obj' and re.match(tspec, obj_fqn)
+                if match_kind or match_obj:
+                    return helper
+
+
+def fully_qualified_name(obj):
+    """
+    Return the fully‑qualified name of *obj* as a string.
+
+    Works for functions, classes, methods, and class/instance attributes.
+    """
+    # For bound methods, the underlying function holds the real name
+    if hasattr(obj, "__func__"):  # e.g. instance.method
+        obj = obj.__func__
+    if hasattr(obj, "__class__"):
+        obj = obj.__class__
+
+    module = getattr(obj, "__module__", None)
+    qualname = getattr(obj, "__qualname__", None)
+
+    if module and qualname:
+        return f"{module}.{qualname}"
+    elif module:
+        return f'{module}'
+    elif qualname:  # built‑ins like <class 'int'>
+        return qualname
+    elif isclass(obj):
+        return repr(obj)
+    return '__noname__'

--- a/omegaml/notebook/jobs.py
+++ b/omegaml/notebook/jobs.py
@@ -184,7 +184,7 @@ class NotebookMixin:
         """
         return len(super().list(name)) + len(super().list(name + '.ipynb')) > 0
 
-    def create(self, code, name):
+    def create(self, code, name, **kwargs):
         """
         create a notebook from code
 
@@ -196,7 +196,7 @@ class NotebookMixin:
         cells.append(nbv4.new_code_cell(source=code))
         notebook = nbv4.new_notebook(cells=cells)
         # put the notebook
-        meta = self.put(notebook, name)
+        meta = self.put(notebook, name, **kwargs)
         return meta
 
     def get_fs(self, collection=None):

--- a/omegaml/store/base.py
+++ b/omegaml/store/base.py
@@ -430,7 +430,7 @@ class OmegaStore(object):
         for name in objs:
             try:
                 backend = self.get_backend(name)
-                drop = backend.drop if backend else self._drop
+                drop = backend.drop if hasattr(backend, 'drop') else self._drop
                 result = drop(name, force=force, version=version, **kwargs)
             except Exception as e:
                 result = False
@@ -620,14 +620,15 @@ class OmegaStore(object):
             return None
         if not force_python:
             backend = (self.get_backend(name, model_store=model_store,
-                                        data_store=data_store)
-                       if not kind else self.get_backend_bykind(kind, model_store=model_store, data_store=data_store))
+                                        data_store=data_store, **kwargs)
+                       if not kind else self.get_backend_bykind(kind, model_store=model_store,
+                                                                data_store=data_store, **kwargs))
             if backend is not None:
                 # FIXME: some backends need to get model_store, data_store, but fails tests
                 return backend.get(name, **kwargs)  # model_store=model_store, data_store=data_store, **kwargs)
         # catch-call to CoreObjectsBackend or force python
         # -- keeping the same behavior until version 0.17, handling all other KINDs
-        core_backend = self.get_backend_bykind('core.object', model_store=model_store, data_store=data_store)
+        core_backend = self.get_backend_bykind('core.object', model_store=model_store, data_store=data_store, **kwargs)
         if force_python:
             return core_backend.get_object_as_python(meta, version=version)
         return core_backend.get(name, version=version, force_python=force_python, **kwargs)

--- a/omegaml/tests/core/test_objhelper.py
+++ b/omegaml/tests/core/test_objhelper.py
@@ -1,0 +1,134 @@
+from unittest import TestCase
+
+from sklearn.linear_model import LinearRegression
+
+from omegaml import Omega
+from omegaml.backends.virtualobj import virtualobj
+from omegaml.mixins.store.objhelper import ObjectHelperMixin
+from omegaml.tests.util import OmegaTestMixin
+
+
+class ObjectHelperTests(OmegaTestMixin, TestCase):
+    def setUp(self):
+        om = self.om = Omega()
+        om.datasets.register_mixin(ObjectHelperMixin)
+        om.models.register_mixin(ObjectHelperMixin)
+        om.jobs.register_mixin(ObjectHelperMixin)
+        self.clean()
+
+    def test_dataset_helper(self):
+        """ test using a helper for datasets """
+        om = self.om
+
+        @virtualobj
+        def myhelper(*args, method=None, universe=None, **kwargs):
+            # print("helper", args, kwargs)
+            if method == 'get' and universe:
+                return 42
+            # returning None triggers usual backend handling
+            return None
+
+        om.datasets.put(myhelper, 'myhelper', force=True)
+        om.datasets.put([0], 'mydata', helper='myhelper')
+        # .get() is run through the normal backend
+        data = om.datasets.get('mydata')
+        self.assertEqual(data, [[0]])
+        # trigger custom helper
+        # -- note universe=True is specific to our myhelper implementation
+        data = om.datasets.get('mydata', universe=True)
+        self.assertEqual(data, 42)
+
+    def test_model_helper(self):
+        om = self.om
+
+        @virtualobj
+        def myhelper(*args, method=None, store=None, meta=None, raw=False, **kwargs):
+            # print("helper", args, kwargs)
+            if method == 'get' and not raw:
+                # simulate loading of the actual model
+                class SomeModel:
+                    def predict(self, *args):
+                        return store.get(meta.name, raw=True)(*args)
+
+                return SomeModel()
+            # returning None triggers usual backend handling
+            return None
+
+        @virtualobj
+        def mymodel(*args, **kwargs):
+            # print("model", args, kwargs)
+            return 42
+
+        # test helper is called
+        om.models.put(myhelper, 'myhelper', force=True)
+        om.models.put(mymodel, 'mymodel', helper='myhelper', force=True)
+        model = om.models.get('mymodel')
+        self.assertEqual(model.predict(), 42)
+        # test versioning
+        om.models.put(mymodel, 'mymodel', helper='myhelper', tag='v1', force=True)
+        meta = om.models.put(mymodel, 'mymodel', helper='myhelper', tag='v2', force=True)
+        model = om.models.get('mymodel')
+        versions = meta.attributes['versions']
+        self.assertIn('tags', versions)
+        self.assertTrue(all(k in versions['tags'] for k in ('latest', 'v1', 'v2')))
+        self.assertEqual(model.predict(), 42)
+        # add a version without a helper
+        meta = om.models.put(mymodel, 'mymodel', tag='v3', force=True)
+        # -- get back the model, now without a helper (helper= was not specified for model version)
+        # -- we get back the mymodel function directly
+        model = om.models.get('mymodel')
+        self.assertTrue(not hasattr(model, 'predict'))
+        self.assertEqual(model(), 42)
+        # get back a previous version that had a helper
+        model = om.models.get('mymodel@v2')
+        self.assertEqual(model.predict(), 42)
+        # can also get back a helper by specifying get(..., helper='name')
+        model = om.models.get('mymodel@v3', helper='myhelper')
+        self.assertEqual(model.predict(), 42)
+
+    def test_job_helper(self):
+        """ test using a helper for jobs """
+        om = self.om
+
+        @virtualobj
+        def myhelper(*args, method=None, store=None, meta=None, raw=False, backend=None, **kwargs):
+            # print("helper", inspect.getargvalues(inspect.currentframe()))
+            from nbformat.v4 import new_code_cell
+            from omegaml.util import utcnow
+            if method == "get":
+                # e.g. add a "created cell"
+                nb = backend.get(meta.name)
+                cell = new_code_cell(f"created {utcnow()}")
+                nb.cells.append(cell)
+                return nb
+
+        code = """
+        print('hello')
+        """
+
+        om.jobs.put(myhelper, 'myhelper', replace=True)
+        om.jobs.create(code, 'myjob', helper='myhelper')
+        nb = om.jobs.get('myjob')
+        self.assertEqual(len(nb.cells), 2)
+        self.assertRegexpMatches(nb.cells[-1]['source'], r'\d{4}-\d{2}-\d{2}.*')
+
+    def test_supports(self):
+        """ test using helper selection by supports= conditions """
+        om = self.om
+
+        @virtualobj
+        def myhelper(*args, method=None, store=None, meta=None, raw=False, **kwargs):
+            if method == 'get':
+                return 42
+
+        # selection by kind
+        om.datasets.put(myhelper, 'myhelper', supports='python.data', replace=True)
+        meta = om.datasets.put({}, 'somedata')
+        result = om.datasets.get('somedata')
+        self.assertEqual(result, 42)
+        # selection by object
+        om.models.put(myhelper, 'myhelper', supports='sklearn.linear.*', replace=True)
+        reg = LinearRegression()
+        om.models.put(reg, 'myreg')
+        result = om.models.get('myreg')
+        self.assertEqual(result, 42)

--- a/omegaml/tests/util.py
+++ b/omegaml/tests/util.py
@@ -36,9 +36,8 @@ class OmegaTestMixin(object):
             if element == 'streams':
                 drop_kwargs = {'keep_data': False}
             # drop all members
-            [drop(m.name,
-                  force=True,
-                  **drop_kwargs) for m in part.list(hidden=True, include_temp=True, raw=True)]
+            [drop(m.name, force=True, **drop_kwargs)
+             for m in part.list(hidden=True, include_temp=True, raw=True)]
             # ignore system members, as they may get recreated e.g. by LunaMonitor
             existing = [m.name for m in part.list(hidden=True, include_temp=True, raw=True)
                         if not '.system' in m.name]


### PR DESCRIPTION
Adds object helpers to models, datasets and jobs. 

Object helpers are dynamic backends and make it easy to deploy arbitrary models, data sources and job/scheduling flows, without the need to write custom backends. 

- any virtualobj can be stored and used as a dynamic backend ("helper")
- Backend.supports-style automatic resolving of helpers
- supports='obj:module.*' selects helper for any obj in module.*
- supports='kind:python.data' selects helper for any obj of type meta.kind == python.data
- fix NotebookMixin.metadata()

this provides infrastructure to #517 