### PR TITLE
fix usage tracking for streaming responses

### DIFF
--- a/omegaml/backends/genai/textmodel.py
+++ b/omegaml/backends/genai/textmodel.py
@@ -817,6 +817,9 @@ class OpenAIProvider(Provider):
         return response
 
     def complete(self, messages, stream=False, model=None, **kwargs):
+        if stream:
+            # https://community.openai.com/t/usage-stats-now-available-when-using-streaming-with-the-chat-completions-api-or-completions-api/738156
+            kwargs.setdefault('stream_options', {"include_usage": True})
         response = self.client.chat.completions.create(
             model=model or self.model,
             messages=messages,

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from importlib import import_module
-
 import json
 import logging
 import os
@@ -9,17 +7,19 @@ import sys
 import tempfile
 import threading
 import uuid
-import validators
 import warnings
 from base64 import b64encode
-from bson import ObjectId
 from copy import deepcopy
 from datetime import datetime, date, timezone
 from hashlib import sha256
+from importlib import import_module
 from importlib.util import find_spec
 from pathlib import Path
 from shutil import rmtree
 from typing import Iterator, Any
+
+import validators
+from bson import ObjectId
 
 try:
     import urlparse
@@ -1247,7 +1247,7 @@ def batched(iterable, batch_size):
 
 
 ensure_list = lambda v: v if isinstance(v, (list, tuple)) else list(v) if isinstance(v, range) else [v]
-ensure_dict = lambda v: v if isinstance(v, dict) else tryOr(lambda v: v.to_dict(), tryOr(lambda v: dict(v), v))
+ensure_dict = lambda v: v if isinstance(v, dict) else tryOr(lambda: v.to_dict(), tryOr(lambda: dict(v), v))
 
 
 def tqdm_if_interactive():


### PR DESCRIPTION
- add stream_options to OpenAI API, according to https://community.openai.com/t/usage-stats-now-available-when-using-streaming-with-the-chat-completions-api-or-completions-api/738156
- ensure ChatCompletion is parsed as a dict