### PR TITLE
feat: enable generic generic model backend

### DIFF
--- a/omegaml/backends/genericmodel.py
+++ b/omegaml/backends/genericmodel.py
@@ -1,0 +1,39 @@
+import joblib
+
+from omegaml.backends.basemodel import BaseModelBackend
+
+
+class GenericModelBackend(BaseModelBackend):
+    """ a generic model backend enabling custom serializers
+
+    supports arbitrary model saving and loading for use in a @virtualobj function
+
+    Usage:
+        # save any model
+        om.models.put(model, 'name', kind='python.model',
+                        serializer=lambda store, model, filename: ...)
+
+        # load any model
+        model = om.models.get(model, 'name',
+                        loader=lambda store, filename: ...)
+
+        # use a virtualobj to load the model with a custom loader
+        @virtualobj
+        def mymodel(*args, **kwargs):
+            model = om.models.get(model, 'name',
+                        loader=lambda store, filename: ...)
+
+    See Also:
+        - TestPytorchModels.test_pytorch_model_genericmodel
+
+    .. versionadded:: NEXT
+        backend kind='python.model' supports custom serializers
+    """
+    KIND = 'python.model'
+
+    serializer = lambda store, model, filename, **kwargs: joblib.dump(model, filename)[0]
+    loader = lambda store, infile, filename=None, **kwargs: joblib.load(infile)
+
+    @classmethod
+    def supports(cls, obj, name, model_store=None, kind=None, **kwargs):
+        return model_store.prefix == 'models/' and kind == 'python.model'

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -122,6 +122,7 @@ OMEGA_STORE_BACKENDS = {
     'pipsrc.package': 'omegaml.backends.package.PythonPipSourcedPackageData',
     'pandas.csv': 'omegaml.backends.externaldata.PandasExternalData',
     'script.ipynb': 'omegaml.notebook.jobs.NotebookBackend',
+    'python.model': 'omegaml.backends.genericmodel.GenericModelBackend',
     # must be last backend listed as a catch-call
     'core.object': 'omegaml.backends.coreobjects.CoreObjectsBackend',
 }


### PR DESCRIPTION
- supports arbitry model saving and loading for use in virtualobj
- simplifies writing serializer and loader code by abstracting the _package_model, _extract_model methods
- om.models.put(model, 'name', kind='python.model', serializer=lambda store, model, filename: ...)
- om.models.get(model, 'name', loader=lambda store, filename: ...)