### PR TITLE
feat: enable rawfiles and models stored to arbitry remote uri

### DIFF
--- a/omegaml/backends/rawfiles.py
+++ b/omegaml/backends/rawfiles.py
@@ -1,6 +1,7 @@
+import os
 from os.path import dirname, basename
 
-import os
+import smart_open
 
 from omegaml.backends.basedata import BaseDataBackend
 
@@ -34,7 +35,7 @@ class PythonRawFileBackend(BaseDataBackend):
             return False
         return True
 
-    def get(self, name, local=None, mode='wb', open_kwargs=None, **kwargs):
+    def get(self, name, local=None, mode='wb', open_kwargs=None, chunksize=None, uri=None, **kwargs):
         """
         get a stored file as a file-like object with binary contents or a local file
 
@@ -45,6 +46,7 @@ class PythonRawFileBackend(BaseDataBackend):
                to be a directory name, in which case the file is stored as the
                same name.
             mode (str): the mode to use on .open() for the local file
+            chunksize (int): optional, the size of chunks to be read, as in
             open_kwargs (dict): the kwargs to use .open() for the local file
             **kwargs: any kwargs passed to datasets.metadata()
 
@@ -56,32 +58,57 @@ class PythonRawFileBackend(BaseDataBackend):
             https://docs.python.org/3/glossary.html#term-file-object
             https://docs.python.org/3/glossary.html#term-binary-file
         """
-        outf = self.data_store.metadata(name, **kwargs).gridfile
+        meta = self.data_store.metadata(name, **kwargs)
+        chunksize = chunksize or 1024 * 1024 * 4
+        uri = uri or meta.uri
+        if uri:
+            outf = open(uri, mode='rb')
+        else:
+            outf = self.data_store.metadata(name, **kwargs).gridfile
         if local:
             is_filename = '.' in basename(local)
             target_dir = dirname(local) if is_filename else local
             local = local if is_filename else '{local}/{name}'.format(**locals())
             os.makedirs(target_dir, exist_ok=True)
             open_kwargs = open_kwargs or {}
-            with open(local, mode=mode, **open_kwargs) as flocal:
-                flocal.write(outf.read())
+            with smart_open.open(local, mode=mode, **open_kwargs) as flocal:
+                while data := outf.read(chunksize):
+                    flocal.write(data)
             return local
         return filelike(outf)
 
-    def put(self, obj, name, attributes=None, encoding=None, **kwargs):
+    def put(self, obj, name, attributes=None, encoding=None, uri=None, **kwargs):
+        """
+        store the binary contents of a file-like object
+
+        Args:
+            obj (str|Path|filelike): the object to be stored
+            name (str): the name for the object's metadata
+            attributes (dict): optional, metadata attributes
+            encoding (str): optional, a valid encoding, such as utf8
+            uri (str): optional, the local or remote file url compatible with smart_open
+            **kwargs:
+
+        Returns:
+            Metadata
+        """
         self.data_store.drop(name, force=True)
         storekey = self.data_store.object_store_key(name, 'file', hashed=True)
-        gridfile = self._store_to_file(self.data_store, obj, storekey, encoding=encoding)
+        gridfile = self._store_to_file(self.data_store, obj, storekey, encoding=encoding, uri=uri,
+                                       **kwargs)
         return self.data_store._make_metadata(
             name=name,
             prefix=self.data_store.prefix,
             bucket=self.data_store.bucket,
             kind=self.KIND,
             attributes=attributes,
+            uri=str(uri or ''),
             gridfile=gridfile).save()
 
 
 def filelike(obj):
-    actual = obj.get()
+    # convert GridFsProxy to GridOut, a filelike object
+    # -- for actual files, returns just the actual file
+    actual = obj.get() if hasattr(obj, 'get') else obj
     __doc__ = actual.__doc__
     return actual

--- a/omegaml/backends/scikitlearn.py
+++ b/omegaml/backends/scikitlearn.py
@@ -130,7 +130,7 @@ class ScikitLearnBackendV2(ScikitLearnBackendV1):
     def put_model(self, obj, name, attributes=None, _kind_version=None, **kwargs):
         if _kind_version and _kind_version != self._backend_version:
             return super()._v1_put_model(obj, name, attributes=attributes, **kwargs)
-        return super().put_model(obj, name, attributes=attributes)
+        return super().put_model(obj, name, attributes=attributes, **kwargs)
 
     def predict(
             self, modelname, Xname, rName=None, pure_python=True, **kwargs):

--- a/omegaml/backends/tensorflow/tfkeras.py
+++ b/omegaml/backends/tensorflow/tfkeras.py
@@ -34,7 +34,7 @@ class TensorflowKerasBackend(KerasBackend):
             except NotImplementedError:
                 pass
 
-    def _extract_model(self, infile, key, tmpfn):
+    def _extract_model(self, infile, key, tmpfn, **kwargs):
         # override to implement model loading
         from tensorflow import keras
         with open(tmpfn, 'wb') as pkgfn:

--- a/omegaml/backends/virtualobj.py
+++ b/omegaml/backends/virtualobj.py
@@ -1,8 +1,9 @@
 import builtins
-import dill
 import sys
 import types
 import warnings
+
+import dill
 
 from omegaml.backends.basedata import BaseDataBackend
 from omegaml.util import tryOr

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ install_deps = [
     'yaspin',
     'honcho>=1.0.1',  # not strictly required, but used in docker compose
     'tabulate>=0.8.2',  # required in cli
-    'smart_open',  # required in cli
+    'smart_open',  # required to handle remote uri storage
     'imageio>=2.3.0',  # require to store images
     'psutil>=5.8',  # required for profiling tracker
     'cachetools>=5.0.0',  # required for session caching


### PR DESCRIPTION
- om.models/datasets.put(file-like, 'name', uri='[scheme://]/path/to/file')
- uri opening is handled using smart_open