### PR TITLE
fix envinstall fails in weird ways

### DIFF
--- a/omegaml/backends/rawfiles.py
+++ b/omegaml/backends/rawfiles.py
@@ -1,3 +1,4 @@
+import io
 import os
 from os.path import dirname, basename
 
@@ -22,12 +23,15 @@ class PythonRawFileBackend(BaseDataBackend):
         is_filelike = hasattr(obj, 'read')
         open_kwargs = dict(open_kwargs or {})
         if kwargs.get('kind') == self.KIND:
-            is_filelike = self._is_openable(self, obj, **open_kwargs)
+            is_filelike |= self._is_openable(self, obj, **open_kwargs)
         return is_filelike or self._is_path(self, obj)
 
     def _is_openable(self, obj, **kwargs):
         if 'mode' not in 'kwargs':
             kwargs['mode'] = 'rb'
+        # already opened file
+        if isinstance(obj, io.IOBase):
+            return not obj.closed
         try:
             with open(obj, **kwargs) as fin:
                 fin.read(1)

--- a/omegaml/celery_util.py
+++ b/omegaml/celery_util.py
@@ -1,8 +1,8 @@
 import getpass
-
 import sys
-from celery import Task
 from contextlib import contextmanager
+
+from celery import Task
 from kombu.serialization import registry
 from kombu.utils import cached_property
 
@@ -108,7 +108,8 @@ class OmegamlTask(EagerSerializationTaskMixin, Task):
         exp = self.tracking.experiment
         meta = delegate_provider.metadata(name)
         exp.log_artifact(meta, 'related')
-        meta = delegate_provider.link_experiment(name, exp._experiment)
+        if delegate_provider.is_trackable(name):
+            meta = delegate_provider.link_experiment(name, exp._experiment)
         return meta
 
     @property

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -83,6 +83,12 @@ OMEGA_CELERY_CONFIG = {
     # TODO replace result backend with redis or mongodb
     'CELERY_RESULT_BACKEND': OMEGA_RESULT_BACKEND,
     'CELERY_ALWAYS_EAGER': True if OMEGA_LOCAL_RUNTIME else False,
+    #: required for task execution visibility
+    'CELERY_TRACK_STARTED': True,
+    """
+    .. versionchanged:: NEXT
+        The default value is now True to enable task status visibility for STARTED vs PENDING
+    """
     'CELERYBEAT_SCHEDULE': {
         'execute_scripts': {
             'task': 'omegaml.notebook.tasks.execute_scripts',

--- a/omegaml/mixins/store/tracking.py
+++ b/omegaml/mixins/store/tracking.py
@@ -9,6 +9,9 @@ class TrackableMetadataMixin:
     def supports(cls, store, **kwargs):
         return store.prefix in ('models/')
 
+    def is_trackable(self, name, **kwargs):
+        return TrackableMetadataMixin.supports(self, name=name, **kwargs)
+
     def link_experiment(self, name, experiment, label=None):
         """
         This links a model to an experiment by adding the experiment name to the
@@ -83,14 +86,21 @@ class TrackableMetadataMixin:
         return meta.save()
 
 
-class UntrackableMetadataMixin:
+class UntrackableMetadataMixin(TrackableMetadataMixin):
     """ placeholder for objects other than models (future use)
+
+    Issues a warning on calling .link_experiment(), .link_monitor() for
+    objects outside the models store
     """
 
     # this enables simplified code in OmegaTask.enable_delegate_tracking
     @classmethod
     def supports(cls, store, **kwargs):
-        return not store.prefix in ('models/')
+        return store.prefix not in ('models/',)
+
+    def is_trackable(self, name, **kwargs):
+        # override is_trackable to avoid accidental change of functionality
+        return False
 
     def link_experiment(self, name, experiment, **kwargs):
         warnings.warn(f'link_experiment is not supported for {self.prefix} store')

--- a/omegaml/runtimes/envinstall/README
+++ b/omegaml/runtimes/envinstall/README
@@ -1,0 +1,1 @@
+omega-ml runtime envinstall

--- a/omegaml/runtimes/envinstall/envinstall/__init__.py
+++ b/omegaml/runtimes/envinstall/envinstall/__init__.py
@@ -1,5 +1,7 @@
 import os
+import shlex
 import subprocess
+from pathlib import Path
 
 
 def run(om, *args, package=None, requirements=None, action='install', options=None, **kwargs):
@@ -20,36 +22,50 @@ def run(om, *args, package=None, requirements=None, action='install', options=No
         om runtime script envinstall run action=uninstall
     """
     lockfile = '/tmp/envinstall.lock'
-    reqfile = requirements or '.system/requirements.txt'
-    package = package or ' '
+    reqfile_dataset = requirements or '.system/requirements.txt'  # from om.datasets
+    reqfile_local = Path(om.scripts.tmppath) / 'requirements.txt'  # for pip
+    package = package or ''
+    package = ' '.join(package) if isinstance(package, (list, tuple)) else package
+    result = 'envinstall has not been executed'
     try:
+        # only run if we can get an exclusive lock to avoid parallel pip installs
         with open(lockfile, 'x') as flock:
-            # only run if we can get an exclusive lock
-            reqfn = '/tmp/envreq.txt'
-            if reqfile:
-                with open(reqfn, 'wb') as fout:
-                    reqs = om.scripts.get(reqfile).read()
+            # -- determine requirements
+            reqspec = f'{package}'
+            if om.scripts.exists(reqfile_dataset):
+                with open(reqfile_local, 'wb') as fout:
+                    reqs = om.scripts.get(reqfile_dataset).read()
                     fout.write(reqs)
-                reqspec = f'-r {reqfn}'
-            else:
-                reqspec = package
+                reqspec = f'-r {reqfile_local} {reqspec}'
+            assert reqspec, "specify either package= or requirements= (no default .system/requirements.txt exists)"
+            # -- determine action
             action_opts = {
                 'install': f'-U --user {reqspec}',
                 'uninstall': f'-y {reqspec}'
             }
             opts = options or action_opts.get(action) or ''
+            # run pip install
             pipcmd = f'pip {action} {opts}'
-            process = subprocess.run(pipcmd.split(' '),
+            om.logger.info(f'running {pipcmd}')
+            process = subprocess.run(shlex.split(pipcmd),
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,
                                      encoding='utf-8')
-    except IOError as e :
-        result = f'another envinstall process is running on this node: {e}'
+            om.logger.info(f'** finished running {pipcmd} {process}')
+    except IOError as e:
+        result = f'envinstall cannot run due to another pip install is running on this node: {e}'
+        om.logger.error(result)
+        raise ValueError(result)
+    except Exception as e:
+        result = f'envinstall failed due to {e}'
+        om.logger.error(result)
+        raise ValueError(result)
     else:
         result = str(process.stdout)
     finally:
-        try:
-            os.remove(lockfile)
-        except:
-            pass
+        for fn in (lockfile, reqfile_local):
+            try:
+                os.remove(fn)
+            except:
+                pass
     return result

--- a/omegaml/runtimes/runtime.py
+++ b/omegaml/runtimes/runtime.py
@@ -227,7 +227,9 @@ class OmegaRuntime(object):
         Returns:
             self
         """
-        if label is not None:
+        if label:
+            # avoid overriding a previous local() call by an erronous label
+            assert isinstance(label, str), "label must be valid, run om.runtime.labels() to list of active workers"
             if label == 'local':
                 self.mode(local=True)
             elif override:

--- a/omegaml/store/base.py
+++ b/omegaml/store/base.py
@@ -769,7 +769,11 @@ class OmegaStore(object):
         # cleanup any temporary files on exit
         # -- this is called as a finalizer (weakref.finalize)
         try:
-            logger.debug(f'finalizing {objrepr}: cleaning up temporary files in {tmppath}')
             shutil.rmtree(tmppath, ignore_errors=True)
         except Exception as e:
             logger.error(f'finalizing {objrepr}: error occured as {e}')
+            return
+        try:
+            logger.debug(f'finalizing {objrepr}: cleaning up temporary files in {tmppath}')
+        except Exception:
+            pass

--- a/omegaml/tests/core/cli/scenarios.py
+++ b/omegaml/tests/core/cli/scenarios.py
@@ -1,10 +1,10 @@
+import os
 import string
+import sys
 from collections import defaultdict
 
 import numpy as np
-import os
 import pandas as pd
-import sys
 from nbformat import v4
 from sklearn.linear_model import LinearRegression
 
@@ -17,6 +17,7 @@ class CliTestScenarios:
     def setUp(self):
         super().setUp()
         self.pretend_logger = None
+        self.cli_logger = self.get_test_logger()
 
     def get_test_logger(self):
         """
@@ -77,7 +78,7 @@ class CliTestScenarios:
         return logger.data[level]
 
     def get_log(self, level, as_text=False):
-        entries =  self.cli_logger.data[level.lower()]
+        entries = self.cli_logger.data[level.lower()]
         return list(' '.join(args) for args in entries) if as_text else entries
 
     def assertLogSize(self, level, size):
@@ -122,14 +123,14 @@ class CliTestScenarios:
         if not match:
             raise AssertionError(f'{expected} is not in {data} compared as {compare_as}')
 
-    def cli(self, argv, new_start=False, **kwargs):
+    def cli(self, argv, new_start=False, debug=True, **kwargs):
         self.cli_logger = self.get_test_logger()
         if new_start:
             self.cli_logger.clear()
             self.pretend_logger.clear() if self.pretend_logger else None
         if isinstance(argv, str):
             argv = argv.split(' ')
-        self.cli_parser = cli.main(argv=argv, logger=self.cli_logger, **kwargs)
+        self.cli_parser = cli.main(argv=argv, logger=self.cli_logger, debug=debug, **kwargs)
         return self.cli_parser
 
     def make_model(self, name):
@@ -201,4 +202,3 @@ class CliTestScenarios:
         basepath = os.path.join(os.path.dirname(sys.modules['omegaml'].__file__), 'example')
         pkgpath = os.path.abspath(os.path.join(basepath, 'demo', 'helloworld'))
         return pkgpath
-

--- a/omegaml/tests/core/test_store.py
+++ b/omegaml/tests/core/test_store.py
@@ -971,8 +971,16 @@ class StoreTests(unittest.TestCase):
         store = self._make_store()
         # test we can write from a file-like object
         data = "some data"
+        # saving an open file implicitely
         file_like = BytesIO(data.encode('utf-8'))
         meta = store.put(file_like, 'myfile')
+        self.assertEqual(data.encode('utf-8'), store.get('myfile').read())
+        self.assertEqual(data.encode('utf-8'), meta.gridfile.read())
+        # saving an open file explicitely
+        with warnings.catch_warnings(record=True) as w:
+            file_like = BytesIO(data.encode('utf-8'))
+            meta = store.put(file_like, 'myfile', kind=PythonRawFileBackend.KIND)
+        self.assertEqual(len(w), 0)
         self.assertEqual(data.encode('utf-8'), store.get('myfile').read())
         self.assertEqual(data.encode('utf-8'), meta.gridfile.read())
         # test we can write from an actual file


### PR DESCRIPTION
om runtime env install accepts requirements.txt, one or multiple packages, or a combination
- envinstall script performs as expected, validates inputs
- remove erronous runtime warnings
- fixes #536