### PR TITLE
feat: enable pytorch model saving using implied helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	pip install --ignore-installed -U pip
 	pip install -U pytest tox tox-conda tox-run-before
 	[ -z "${RUNTESTS}" ] && (pip install gil && gil clone && pip install -r requirements.dev) || echo "env:RUNTESTS set, using packages from pypi only"
-	pip install ${PIPOPTS} --progress-bar off -e ".[${EXTRAS}]" "${PIPREQ}"
+	pip install ${PIPOPTS} --progress-bar off -e ".[${EXTRAS}]" "${PIPREQ}" --extra-index-url https://download.pytorch.org/whl/cpu
 	(which R && scripts/runtime/setup-r.sh) || echo "R is not installed"
 	scripts/install-oras.sh || echo "oras is not installed"
 

--- a/omegaml/backends/genericmodel.py
+++ b/omegaml/backends/genericmodel.py
@@ -36,4 +36,43 @@ class GenericModelBackend(BaseModelBackend):
 
     @classmethod
     def supports(cls, obj, name, model_store=None, kind=None, **kwargs):
-        return model_store.prefix == 'models/' and kind == 'python.model'
+        explicit = model_store.prefix == 'models/' and kind == 'python.model'
+        implicit = model_store.prefix == 'models/' and isinstance(obj, tuple) and callable(obj[-1])
+        implicit |= any(callable(kwargs.get(k)) for k in ('serializer', 'loader'))
+        return explicit or implicit
+
+    def put(self, obj, name, uri=None, serializer=None, loader=None, **kwargs):
+        """ save any model using custom serializer and loader
+
+        Args:
+            obj (any|tuple): model instance or a tuple of (instance, helper), where
+                helper is a @virtualobj callable that will be used as the helper
+            name (str): name of the object
+            uri (str): optional, the path to a storage location supported by smart_open,
+             if not provided defaults to metadata.gridfile
+            serializer (callable): a callable, serializer(store, model, filename, **kwargs),
+               where store is self, model is obj, filename is the /path/to/file of the
+               serialized object. serializer() must return the actual filename or None
+            loader (callable): a callable, loader(store, infile, **kwargs), where
+               store is self, infile is the opened file-like object to be read from.
+               loader() must return the deserialized model object
+            **kwargs (dict): optional, passed on to delegate .put(), the delegate being
+              either the helper, super(), or another backend suitable for this model
+
+        Returns:
+            metadata (Metadata): the metadata object created from this object
+        """
+        if isinstance(obj, tuple) and callable(obj[-1]):
+            # assume a helper has been provided, store it and pass along
+            model, vobj = obj
+            helper_name = f'.helpers/{name}'
+            self.model_store.put(vobj, helper_name, replace=True, noversion=True)
+            kwargs.update(helper=helper_name)
+        else:
+            # just a model, no helper
+            model = obj
+        if callable(serializer) or callable(loader):
+            # BaseModelbackend will handle serializer and loader
+            return super().put(model, name, uri=uri, serializer=serializer, loader=loader, **kwargs)
+        # called explicitly, use normal backend
+        return self.model_store.put(model, name, uri=uri, **kwargs)

--- a/omegaml/backends/pytorch.py
+++ b/omegaml/backends/pytorch.py
@@ -1,0 +1,22 @@
+import dill
+import torch
+
+from omegaml.backends.basemodel import BaseModelBackend
+
+
+class PytorchModelBackend(BaseModelBackend):
+    """ Backend to store pytorch models
+
+    Saves pytorch models using the generic torch.save() and torch.load() methods.
+    For other torch saving and loading methods, use a helper virtualobj.
+
+    See Also:
+        - https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html
+    """
+    KIND = 'pytorch.pth'
+
+    serializer = lambda store, model, filename, **kwargs: torch.save(model, filename, pickle_module=dill)
+    loader = lambda store, infile, filename=None, **kwargs: torch.load(infile, pickle_module=dill, weights_only=False)
+    types = torch.nn.Module
+    infer = lambda obj, **kwargs: obj
+    reshape = lambda data, **kwargs: torch.tensor(data)

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -157,6 +157,9 @@ OMEGA_STORE_BACKENDS_OPENAI = {
     'pgvector.conx': 'omegaml.backends.genai.pgvector.PGVectorBackend',
     'vector.conx': 'omegaml.backends.genai.mongovector.MongoDBVectorStore',
 }
+OMEGA_STORE_BACKENDS_OPTIONAL = {
+    'pytorch': {'pytorch.pth', 'omegaml.backends.pytorch.PytorchModelBackend'},
+}
 #: supported frameworks (deprecated since 0.16.2, it is effectively ignored)
 OMEGA_FRAMEWORKS = os.environ.get('OMEGA_FRAMEWORKS', 'scikit-learn').split(',')
 if is_test_run:
@@ -477,6 +480,10 @@ def load_framework_support(vars=globals()):
     #: mlflow backends
     if mlflow_available():
         vars['OMEGA_STORE_BACKENDS'].update(vars['OMEGA_STORE_BACKENDS_MLFLOW'])
+    # other backends
+    for mod, backends in vars['OMEGA_STORE_BACKENDS_OPTIONAL'].items():
+        if module_available(mod):
+            vars['OMEGA_STORE_BACKENDS'].update(backends)
 
 
 @inprogress(text='loading configuration...')

--- a/omegaml/mixins/store/modelversion.py
+++ b/omegaml/mixins/store/modelversion.py
@@ -200,7 +200,7 @@ class ModelVersionMixin(object):
         version_name = self._model_version_store_key(meta.name, version_hash)
         version_meta = self.put(obj, version_name, noversion=True, **kwargs)
         version_meta.attributes = deepcopy(meta.attributes)
-        version_meta.attributes.update(kwargs.get('attributes', {}))
+        version_meta.attributes.update(kwargs.get('attributes') or {})  # kwargs attributes can be None
         if 'versions' in version_meta.attributes:
             del version_meta.attributes['versions']
         version_meta.save()

--- a/requirements.dev
+++ b/requirements.dev
@@ -1,2 +1,5 @@
+# cpu-only pytorch
+--extra-index-url https://download.pytorch.org/whl/cpu
+-e .[all,dev]
 -e ../minibatch[all]
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ sec_deps = [
 ai_deps = [
     'openai',
     'markitdown',
+    'torch',
     'pgvector',
     'psycopg2-binary',  # required for pgvector
     'python-jose[cryptography]',  # require for json encyption in async events server


### PR DESCRIPTION
enabling pytorch model saving as pickel objects by default, and in arbitrary format as needed by the user

saving as pickle
- om.models.put(torchmode, 'mymodel')

saving using a helper
- om.models.put(torchmodel, 'mymodel', helper=virtualobj)
- the helper must implement methods put, get and predict