### PR TITLE
chore: fix intermittent build issues

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,11 @@
 services:
   mongo:
     image: mongo:7.0
+    # https://www.mongodb.com/docs/manual/reference/ulimit/
+    ulimits:
+      nofile:
+        soft: 20000
+        hard: 64000
     ports:
       - "27017:27017"
       - "28017:28017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,10 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: foobar
+    ulimits:
+      nofile:
+        soft: 20000
+        hard: 64000
 
 volumes:
   pythonlib:

--- a/omegaml/mdataframe.py
+++ b/omegaml/mdataframe.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
+from uuid import uuid4
+
 import numpy as np
 import pandas as pd
 from bson import Code
 from numpy import isscalar
 from pymongo.collection import Collection
-from uuid import uuid4
 
 from omegaml.store import qops
 from omegaml.store.filtered import FilteredCollection
@@ -663,7 +664,7 @@ class MDataFrame(object):
         if self.force_columns:
             missing = set(self.force_columns) - set(self.columns)
             for col in missing:
-                df[col] = np.NaN
+                df[col] = np.nan
         return df
 
     def _get_cursor(self):

--- a/omegaml/store/base.py
+++ b/omegaml/store/base.py
@@ -234,7 +234,7 @@ class OmegaStore(object):
         bucket = bucket or self.bucket
         # Meta is to silence lint on import error
         Meta = self._Metadata
-        return Meta.objects(name=str(name), prefix=prefix, bucket=bucket).no_cache().first()
+        return Meta.objects(name=str(name), prefix=prefix, bucket=bucket).no_cache().limit(1).first()
 
     def make_metadata(self, name, kind, bucket=None, prefix=None, **kwargs):
         """


### PR DESCRIPTION
this fixes recurring build issues reporting mongodb killed due to signal 6, too many files open

changes
- mongodb in docker engine needs higher ulimits, https://www.mongodb.com/docs/manual/reference/ulimit/
- docker engine defaults to system ulimits, https://docs.docker.com/engine/release-notes/25.0/#new
- match numpy 2.0 np.NaN removal, https://numpy.org/devdocs/release/2.0.0-notes.html
- use a limit(1) cursor on OmegaStore.metadata() to ensure it is closed

rationale
- caused by recent docker engine upgrades causing mongodb to have fd limits of 1024 (system defaults)