### PR TITLE
fix: dashboard.jobs results tab fails to show in case of invalid results

### DIFF
--- a/omegaml/server/dashboard/app.py
+++ b/omegaml/server/dashboard/app.py
@@ -62,11 +62,11 @@ def explain(segment):
     template_string = ""
     defaults = {}
     segments_to_store = {
-        'models': 'model',
+        'models': 'models',
         'datasets': 'dataset',
-        'jobs': 'job',
-        'scripts': 'script',
-        'streams': 'stream',
+        'jobs': 'jobs',
+        'scripts': 'scripts',
+        'streams': 'streams',
         'tracking': 'models',
         'prompts': 'models',
     }

--- a/omegaml/server/dashboard/static/assets/views/repository/jobs_detail.js
+++ b/omegaml/server/dashboard/static/assets/views/repository/jobs_detail.js
@@ -28,7 +28,7 @@ $(function () {
           data: "results",
           render: function (data, type, row, meta) {
             const result_url = url_for("omega-server.jobs_api_get_results", {
-              name: data ? data.replace("results/", "") : "<no results>",
+              name: (data || "") ? data.replace("results/", "") : "<no results>",
             });
             return `<a class="job-result" result-url="${result_url}" href="${result_url}">${data}</a>`;
           },
@@ -46,6 +46,7 @@ $(function () {
           if (e.shiftKey) {
             window.open(result_url, "_blank");
           } else {
+            console.debug("showing job results modal", result_url);
             $("#jobview-modal").attr("result-url", result_url);
             $("#jobview-modal").modal("show");
           }

--- a/omegaml/server/dashboard/templates/dashboard/layouts/detail.html
+++ b/omegaml/server/dashboard/templates/dashboard/layouts/detail.html
@@ -112,9 +112,9 @@
     </div>
   </div>
 </div>
-{% endblock content %}
 {% block extension %}
 {% endblock extension %}
+{% endblock content %}
 <!-- Specific Page JS goes HERE  -->
 {% block javascripts %}
 <script src="{{ config.ASSETS_ROOT }}/plugins/jsoneditor/jsoneditor.min.js"></script>
@@ -140,7 +140,7 @@
       attributes: json,
     };
     $.ajax({
-      url: url_for('.prompts_api_handle_update', { 'name': '{{ meta.name}}' }),
+      url: url_for(".{{ segment }}_api_handle_update", { 'name': '{{ meta.name}}' }),
       type: 'POST',
       contentType: 'application/json',
       dataType: 'json',
@@ -223,7 +223,7 @@
       }
     };
     $.ajax({
-      url: url_for('.index').joinUri('/{{segment}}/{{meta.name}}/update'),
+      url: url_for(".{{ segment }}_api_handle_update", { 'name': '{{ meta.name}}' }),
       type: 'POST',
       contentType: 'application/json',
       dataType: 'json',

--- a/omegaml/server/flaskview.py
+++ b/omegaml/server/flaskview.py
@@ -21,6 +21,9 @@ class FlaskView:
             self._add_route(bp, route, view, options)
 
     def _add_route(self, bp, route, view, options):
+        # add a bp.rule for any @fv.route decorated member fn
+        # -- generates the endpoint as "{self.segment}_{fn.__name__}", unless specified as @fv.route(..., endpoint=...)
+        # -- to reference a specific view fn, use url_for('<blueprint>.<endpoint>') as usual
         kwargs = dict(options)
         kwargs.pop('order', None)  # drop order, it's not a valid kwarg to bp.add_url_rule()
         kwargs.update(

--- a/omegaml/tests/core/test_jobs.py
+++ b/omegaml/tests/core/test_jobs.py
@@ -155,7 +155,7 @@ class JobTests(TestCase):
         runs = meta.attributes['job_runs']
         this_run = runs[0]
         self.assertEqual(this_run['status'], 'ERROR')
-        self.assertIn('execution timed out', this_run['message'])
+        self.assertIn('timed out', this_run['message'])
         self.assertEqual(len(runs), 1)
         # -- retry with no timeout
         om.jobs.drop('testjob', force=True)
@@ -207,7 +207,7 @@ class JobTests(TestCase):
         runs = meta.attributes['job_runs']
         this_run = runs[0]
         self.assertEqual(this_run['status'], 'ERROR')
-        self.assertIn('execution timed out', this_run['message'])
+        self.assertIn('timed out', this_run['message'])
         self.assertEqual(len(runs), 1)
         # -- retry with no timeout
         om.jobs.drop('testjob', force=True)
@@ -244,6 +244,10 @@ class JobTests(TestCase):
         runs = meta.attributes['job_runs']
         self.assertEqual(len(runs), 1)
         self.assertEqual('ERROR', runs[0]['status'])
+        # ensure job_results are recorded for bad state #468
+        resultnb = meta.attributes['job_results'][-1]
+        self.assertEqual(runs[-1]['results'], resultnb)
+        self.assertTrue(om.jobs.exists(resultnb))
 
     def test_run_nonexistent_job(self):
         om = self.om


### PR DESCRIPTION
fixes issues in dashboard.jobs details view

- job's metadata.attributes.job_results[].results always refers to the om.jobs member, regardless of state
- job's metadata.attributes.job_results[].message is truncated to `[:80]...[-80:]` of the full message, reducing metadata object size
- dashboard job details is failsafe to invalid values
- dashboard metadata update uses url_for()
- fixes #468
- fixes #526
- fixes #496 