### PR TITLE
fix: om.jobs.put(code) fails due to missing .create()

### DIFF
--- a/omegaml/notebook/jobs.py
+++ b/omegaml/notebook/jobs.py
@@ -57,7 +57,7 @@ class NotebookBackend(BaseDataBackend):
         if not name.endswith('.ipynb'):
             name += '.ipynb'
         if isinstance(obj, str):
-            return self.create(obj, name)
+            return self.store.create(obj, name)
         sbuf = StringIO()
         bbuf = BytesIO()
         # nbwrite expects string, fs.put expects bytes

--- a/omegaml/tests/core/test_jobs.py
+++ b/omegaml/tests/core/test_jobs.py
@@ -8,7 +8,7 @@ from nbformat import v4
 
 from omegaml import Omega
 from omegaml.documents import Metadata
-from omegaml.notebook.jobs import JobSchedule
+from omegaml.notebook.jobs import JobSchedule, NotebookBackend
 from omegaml.util import settings as omegaml_settings, settings
 
 
@@ -308,6 +308,16 @@ class JobTests(TestCase):
         meta = om.jobs.schedule('testjob', run_at='00 08 * * 1,2,3')
         self._check_scheduled_job()
         self.assertEqual(meta.attributes['config']['run-at'], '00 08 * * 1,2,3')
+
+    def test_create_jobs_from_code(self):
+        om = self.om
+        code = """
+        print('hello')
+        """
+        meta = om.jobs.create(code, 'testjob')
+        self.assertEqual(meta.kind, NotebookBackend.KIND)
+        meta = om.jobs.put(code, 'testjob2')
+        self.assertEqual(meta.kind, NotebookBackend.KIND)
 
     def test_scheduled_job_with_nlp_schedule(self):
         om = self.om


### PR DESCRIPTION
- call mixin.create() instead of backend.create()