### PR TITLE
chore: genai model handling improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ VERSION=$(shell cat omegaml/VERSION)
 # run using make -e to override by env variables
 EXTRAS:=dev
 PIPREQ:=pip
+DISTTAGS:=""
 
 install:
 	# in some images pip is outdated, some packages are system-level installed
@@ -34,7 +35,7 @@ dist: sanity
 	rm -rf ./dist/*
 	rm -rf ./build/*
 	# set DISTTAGS to specify eg --python-tag for bdist
-	python -m build --sdist --wheel --config-setting "--build-option=${DISTTAGS}"
+	python -m build --sdist --wheel --config-setting="--build-option=${DISTTAGS}"
 	twine check dist/*.whl
 
 livetest: dist
@@ -138,8 +139,11 @@ scan: freeze pipsync
 
 server-debug:
 	# start omegaml server
-	export OMEGA_LOCAL_RUNTIME=1; python -m omegaml.server
+	export OMEGA_LOCAL_RUNTIME=1; export OMEGA_LOGLEVE_DEBUG=1; export DEBUG=1; python -m omegaml.server
 
 server:
-	OMEGA_LOGLEVEL=DEBUG honcho -f scripts/local/Procfile start server worker
+	honcho -f scripts/local/Procfile start server worker
+
+server-sse:
+	honcho -f scripts/ssechat/Procfile start web server worker sse
 

--- a/omegaml/backends/genai/models.py
+++ b/omegaml/backends/genai/models.py
@@ -57,7 +57,7 @@ class GenAIBaseBackend(VirtualObjectBackend):
         # Xname is the input given by the user
         model: GenAIModel
         model = self.get(modelname)
-        model.load('complete')
+        model.load()
         data = self._resolve_input_data('complete', Xname, **kwargs)
         data = data[0] if isinstance(data, list) else data
         if isinstance(data, dict):
@@ -81,13 +81,13 @@ class GenAIBaseBackend(VirtualObjectBackend):
 
     def generate(self, modelname, Xname, rName=None, pure_python=True, **kwargs):
         model = self.get(modelname)
-        model.load('generate')
+        model.load()
         data = self._resolve_input_data('generate', Xname, **kwargs)
         return model.generate(data)
 
     def embed(self, modelname, Xname, rName=None, pure_python=True, **kwargs):
         model = self.get(modelname)
-        model.load('embed')
+        model.load()
         data = self._resolve_input_data('embed', Xname, **kwargs)
         if isinstance(data, str):
             # a single document
@@ -112,7 +112,7 @@ class GenAIBaseBackend(VirtualObjectBackend):
 
 class GenAIModel:
     # model interface for GenAIModelHandler, should not be used directly
-    def load(self, method):
+    def load(self):
         pass
 
     def complete(self, prompt, messages=None, conversation_id=None,
@@ -135,9 +135,8 @@ class GenAIModelHandler(GenAIModel, VirtualObjectHandler):
 
     Usage:
         class MyModelHandler(GenAIModelHandler):
-            def load(self, method):
-                # code to load the model or pipeline for a given method
-                # method is one of 'complete', 'generate', 'finetune', 'embed'
+            def load(self):
+                # code to load the model or pipeline
                 self.model = ...
 
             def complete(self, ):

--- a/omegaml/backends/restapi/streamable.py
+++ b/omegaml/backends/restapi/streamable.py
@@ -106,6 +106,7 @@ class StreamableResourceMixin:
             logger.debug("complete:stream_result waiting for chunks")
             emitter.run(blocking=False)
             for chunk in buffer:
+                logger.debug("complete:stream_result chunk received: %s", chunk)
                 # determine if we should stop
                 finish_reason = chunk.get('stream_complete', '')
                 should_stop = finish_reason.startswith('stop')
@@ -115,7 +116,6 @@ class StreamableResourceMixin:
                     message = chunk.get('message', '')
                     break
                 # process chunk by forwarding to Sink buffer
-                logger.debug("complete:stream_result chunk received: %s", chunk)
                 data = self.prepare_result(chunk, resource_name=resource_name)
                 data.update(data.pop('result', {})) if raw else None
                 yield data

--- a/omegaml/backends/tracking/base.py
+++ b/omegaml/backends/tracking/base.py
@@ -249,6 +249,9 @@ class TrackingProvider:
     def log_event(self, event, key, value, step=None, **extra):
         raise NotImplementedError
 
+    def log_events(self, event, key, values, step=None, dt=None, **extra):
+        raise NotImplementedError
+
     def log_metric(self, key, value, step=None, **extra):
         raise NotImplementedError
 

--- a/omegaml/backends/tracking/simple.py
+++ b/omegaml/backends/tracking/simple.py
@@ -1,16 +1,17 @@
-import dill
 import importlib
-import numpy as np
 import os
-import pandas as pd
 import platform
-import pymongo
 import warnings
 from base64 import b64encode, b64decode
 from datetime import date
 from itertools import chain
 from typing import Iterable
 from uuid import uuid4
+
+import dill
+import numpy as np
+import pandas as pd
+import pymongo
 
 from omegaml.backends.tracking.base import TrackingProvider
 from omegaml.documents import Metadata
@@ -36,6 +37,9 @@ class NoTrackTracker(TrackingProvider):
         pass
 
     def log_event(self, event, key, value, step=None, **extra):
+        pass
+
+    def log_events(self, event, key, values, step=None, dt=None, **extra):
         pass
 
     def log_extra(self, **kwargs):

--- a/omegaml/mixins/store/objhelper.py
+++ b/omegaml/mixins/store/objhelper.py
@@ -96,7 +96,7 @@ class ObjectHelperMixin:
         Returns:
             Metadata
         """
-        has_helper = helper is not None
+        has_helper = bool(helper)
         has_helper_fn = callable(helper) and hasattr(helper, '_omega_virtual')
         if has_helper_fn:
             # save implied helper passed as a callable

--- a/omegaml/server/dashboard/views/genai/prompts.py
+++ b/omegaml/server/dashboard/views/genai/prompts.py
@@ -88,7 +88,7 @@ class AIPromptsView(AIRepositoryView):
         meta.attributes.setdefault('permissions', {
             'groups': data.get('permissions', {}).get('groups', ['sibyl']),
         })
-        meta.save()
+        meta.save(version=True)
         return {'message': 'Prompt saved successfully', 'name': name}, 200
 
 

--- a/omegaml/server/tests/test_prompts.py
+++ b/omegaml/server/tests/test_prompts.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+from flask import url_for
+
+from omegaml.backends.genai.textmodel import TextModel
+from omegaml.server.app import create_app
+from omegaml.tests.util import OmegaTestMixin
+
+
+class PromptsViewTest(OmegaTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.app = create_app()
+        self.app.testing = True
+        self.client = self.app.test_client()
+        globals().update(url_for=self.url_for)
+
+    def url_for(self, endpoint, **kwargs):
+        from flask import url_for
+        with self.app.test_request_context():
+            return url_for(endpoint, **kwargs)
+
+    def test_prompt_save(self):
+        om = self.om
+        om.models.put('openai+http://localhost/mymodel', 'llms/mymodel',
+                      prompt='you are not very helpful')
+        # create a new prompt based on an existing model
+        resp = self.client.post(url_for('omega-ai.prompts_api_save_prompt',
+                                        name='prompts/myprompt'),
+                                json={
+                                    'model': 'llms/mymodel',
+                                    'prompt': 'you are a very helpful assistant',
+                                })
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('prompts/myprompt', om.models.list())
+        meta = om.models.metadata('prompts/myprompt')
+        self.assertEqual(meta.attributes['model'], 'llms/mymodel')
+        self.assertEqual(meta.attributes['prompt'], 'you are a very helpful assistant')
+        prompt = om.models.get('prompts/myprompt')
+        self.assertIsInstance(prompt, TextModel)
+        self.assertEqual(prompt.model, 'mymodel')
+        self.assertEqual(prompt.prompt, 'you are a very helpful assistant')
+        # update the prompt
+        resp = self.client.post(url_for('omega-ai.prompts_api_save_prompt',
+                                        name='prompts/myprompt'),
+                                json={
+                                    'model': 'llms/mymodel',
+                                    'prompt': 'you are a really very helpful assistant',
+                                })
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('prompts/myprompt', om.models.list())
+        meta = om.models.metadata('prompts/myprompt')
+        self.assertEqual(meta.attributes['model'], 'llms/mymodel')
+        self.assertEqual(meta.attributes['prompt'], 'you are a really very helpful assistant')
+        prompt = om.models.get('prompts/myprompt')
+        self.assertIsInstance(prompt, TextModel)
+        self.assertEqual(prompt.model, 'mymodel')
+        self.assertEqual(prompt.prompt, 'you are a really very helpful assistant')

--- a/omegaml/tests/core/restapi/test_ai_restapi.py
+++ b/omegaml/tests/core/restapi/test_ai_restapi.py
@@ -120,11 +120,11 @@ class GenAITestCase(OmegaTestMixin, unittest.TestCase):
         self.assertEqual(resp.headers['Content-Type'], 'text/event-stream')
         data = list(map(lambda d: json.loads(d.split(b'data: ')[-1]) if d.startswith(b'data:') else d,
                         resp.iter_encoded()))
-        self.assertEqual(len(data), len('hello'))
-        # FIXME the 'result' should really be 'content' (for consistency with OpenAI?)
+        self.assertEqual(len(data[-1]['content']), len('hello'))
         self.assertEqual(data[-1], {
             'model': 'mymodel',
-            'content': 'hello', 'delta': 'o',
+            'content': 'hello',
+            'delta': 'o',
             'resource_uri': 'mymodel',
         })
 

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -1411,3 +1411,7 @@ def find_instances(cls):
             # ignore weakref or other issues
             pass
     return instances
+
+
+def raise_(e):
+    raise e


### PR DESCRIPTION
various changes to improve genai model handling

fix: updating prompts in AI lab shall update the actual prompt version

- fixes https://github.com/omegaml/omegaml/issues/546
- error-check loading of pipeline, tools

fix: tool calling from /chat/completions endpoint does not return final result

- return tool-processed response instead of assistant's tool calling response
- add call to pipeline(method='toolprepare', ...) to prepare tool calling
- add TextModel.trace() to trace method calls in interactive mode

chore: improve LLM provider stability

- improve stability across multiple providers
- always process LLM response as dict objects
- stop after tool calls have been processed
- errors in response/chunk processing are logged as tracking.log_event(event='error', ...)
- add tests for model pipeline handling

fix: virtual_genai.load() missing positional argument load

- fixes https://github.com/omegaml/omegaml/issues/547

fix: improve error handling

- streaming messages will pass on error as message