### PR TITLE
feat: configurable default for vector db

### DIFF
--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -262,6 +262,8 @@ OMEGA_CARDS_ENABLED = truefalse(os.environ.get('OMEGA_CARDS_ENABLED', False))
 OMEGA_EVENTS_STREAMER = os.environ.get('OMEGA_EVENTS_STREAMER', 'inline')
 #: events streaming ssechat server
 OMEGA_EVENTS_STREAMER_URL = os.environ.get('OMEGA_EVENTS_STREAMER_URL', '/events/chat/completions')
+#: vector db
+OMEGA_VECTORDB_URL = os.environ.get('OMEGA_VECTORDB_URL', 'vector+mongodb://')
 
 
 # =========================================
@@ -551,7 +553,16 @@ update_from_env()
 
     This is used to configure the omegaml.runtime's celery.App instance. It is a mapping
     of Celery settings. 
-
+  
 .. versionchanged:: NEXT
-    CELERY_TRACK_STARTED=True to enable task status visibility for STARTED vs PENDING
+    CELERY_TRACK_STARTED=True to enable task status visibility for STARTED vs PENDING 
+
+.. py:data:: OMEGA_VECTORDB_URL
+    :type: str
+    
+    The URL to the vector db, used for document indexing. Supports mongodb:// for
+    mongodb, and pgvector:// for PostgreSQL+pgvector 
+    
+.. versionadded:: NEXT
+    OMEGA_VECTORDB_URL 
 """

--- a/omegaml/server/dashboard/views/genai/__init__.py
+++ b/omegaml/server/dashboard/views/genai/__init__.py
@@ -181,12 +181,11 @@ class GenAIView(BaseView):
         description = self.request.json.get('description', '')
         if not index_name:
             abort(400, 'Index name is required')
-        # TODO use om.defaults.variables for the connection string
-        cnxstring = 'pgvector://postgres:test@localhost:5432/postgres'
+        cnxstring = om.defaults.OMEGA_VECTORDB_URL
         attributes = {
             'docs': description,
         }
-        index = om.datasets.put(cnxstring, index_name, kind='pgvector.conx', attributes=attributes)
+        index = om.datasets.put(cnxstring, index_name, attributes=attributes)
         return jsonify({
             'success': True,
             'message': f'Index >{index_name}< created successfully!',


### PR DESCRIPTION
- env.OMEGA_VECTORB_URL sets `vector+mongodb://` as its default