### PR TITLE
chore: deprecate tensorflow, keras backends for python >= 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
               make -e test
               conda deactivate
             }
-            dotest 3.11
+            dotest 3.12
             docker-compose down --remove-orphans
           shell: /bin/bash -l -eo pipefail
       - store_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ install:
 	# https://stackoverflow.com/questions/49911550/how-to-upgrade-disutils-package-pyyaml
 	pip install --ignore-installed -U pip
 	pip install -U pytest tox tox-conda tox-run-before
-	[ -z "${RUNTESTS}" ] && (pip install gil && gil clone && pip install -r requirements.dev) || echo "env:RUNTESTS set, using packages from pypi only"
-	pip install ${PIPOPTS} --progress-bar off -e ".[${EXTRAS}]" "${PIPREQ}" --extra-index-url https://download.pytorch.org/whl/cpu
+	[ -z "${RUNTESTS}" ] && (pip install gil && gil clone) || echo "env:RUNTESTS set, using packages from pypi only"
+	pip install ${PIPOPTS} --progress-bar off -r requirements.dev -e ".[${EXTRAS}]" "${PIPREQ}" --extra-index-url https://download.pytorch.org/whl/cpu
 	(which R && scripts/runtime/setup-r.sh) || echo "R is not installed"
 	scripts/install-oras.sh || echo "oras is not installed"
 
@@ -146,4 +146,7 @@ server:
 
 server-sse:
 	honcho -f scripts/ssechat/Procfile start web server worker sse
+
+lint:
+	ruff check . --select=UP005,UP006 --fix
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-| Version  | Supported          | Python *)               |
-|----------| ------------------ |-------------------------|
-| 0.16.1   | :heavy_check_mark: | 3.9, 3.10, 3.11, (3.12) |
-| 0.16.0   | :heavy_check_mark: | 3.9, 3.10, 3.11, (3.12) |
-| 0.15.4   | :heavy_check_mark: | 3.9, 3.10, (3.11)       |
-| < 0.15.4 | :x:                | 3.7, 3.8, 3.9           |
+| Version  | Supported          | Python *)              |
+|----------|--------------------|------------------------|
+| 0.18.0   | :heavy_check_mark: | 3.10, 3.11, 3.12, 3.13 |
+| 0.17.0   | :heavy_check_mark: | 3.10, 3.11, (3.12+)    |
+| 0.16.4   | :heavy_check_mark: | 3.10, 3.11             |
+| < 0.16.4 | :x:                | 3.10, 3.11., 3.12      |
 
 *) CPython as released by the PSF and compatible distributions, (x) indicates partial support
 
@@ -16,7 +16,7 @@
 Report any observed or suspected vulnerability to security@omegaml.io
 For urgent matters please follow the steps found in https://www.omegaml.io/sirp
 
-## Commercial Services  
+## Commercial Services
 
 Attending to urgent matters in your setup is subject to our license and support terms of services
 as specified at https://www.omegaml.io/eula

--- a/omegaml/backends/tensorflow/__init__.py
+++ b/omegaml/backends/tensorflow/__init__.py
@@ -1,3 +1,5 @@
+from packaging.version import Version
+
 try:
     import tensorflow as tf
 except ModuleNotFoundError:
@@ -10,13 +12,18 @@ else:
 
     # compatibility with previous tensorflow versions
     FN_MAP = {}
-    if tf.__version__.startswith('1.'):
+    tf_version = Version(tf.__version__)
+    if tf_version < Version('2.0'):
         FN_MAP['pandas_input_fn'] = getattr(tf.estimator.inputs, 'pandas_input_fn')
         FN_MAP['numpy_input_fn'] = getattr(tf.estimator.inputs, 'numpy_input_fn')
-        FN_MAP['convert_to_tensor']  = getattr(tf.compat.v1, 'convert_to_tensor')
-    elif tf.__version__.startswith('2.'):
+        FN_MAP['convert_to_tensor'] = getattr(tf.compat.v1, 'convert_to_tensor')
+    elif tf_version < Version('2.6'):
         FN_MAP['pandas_input_fn'] = getattr(tf.compat.v1.estimator.inputs, 'pandas_input_fn')
         FN_MAP['numpy_input_fn'] = getattr(tf.compat.v1.estimator.inputs, 'numpy_input_fn')
+        FN_MAP['convert_to_tensor'] = getattr(tf, 'convert_to_tensor')
+    else:
+        FN_MAP['pandas_input_fn'] = getattr(tf, 'convert_to_tensor')
+        FN_MAP['numpy_input_fn'] = getattr(tf, 'convert_to_tensor')
         FN_MAP['convert_to_tensor'] = getattr(tf, 'convert_to_tensor')
 
 

--- a/omegaml/backends/tensorflow/protobufobj.py
+++ b/omegaml/backends/tensorflow/protobufobj.py
@@ -3,6 +3,13 @@ from omegaml.backends.basedata import BaseDataBackend
 
 
 class ProtobufDataBackend(BaseDataBackend):
+    """
+    .. versionchanged:: NEXT
+        Only supported for tensorflow <= 2.15 and Python <= 3.11
+
+    .. deprecated:: NEXT
+        Use an object helper or a serializer/loader combination instead.
+    """
     KIND = 'protobuf.pbf'
 
     @classmethod
@@ -36,4 +43,3 @@ class ProtobufDataBackend(BaseDataBackend):
         message = load_class(pbtype)()
         message.ParseFromString(data)
         return message
-

--- a/omegaml/backends/tensorflow/tfestimatormodel.py
+++ b/omegaml/backends/tensorflow/tfestimatormodel.py
@@ -1,12 +1,12 @@
 # import glob
 import glob
+import logging
 import os
 import tempfile
 from inspect import isfunction
 from zipfile import ZipFile, ZIP_DEFLATED
 
 import dill
-import logging
 
 from omegaml.backends.basemodel import BaseModelBackend
 
@@ -25,6 +25,12 @@ class TFEstimatorModel(object):
         estimator.predict(input_fn=input_fn)
 
         The estimator_fn returns a tf.estimator.Estimator or subclass.
+
+    .. versionchanged:: NEXT
+        Only supported for tensorflow <= 2.15 and Python <= 3.11
+
+    .. deprecated:: NEXT
+        Use an object helper or a serializer/loader combination instead.
     """
 
     def __init__(self, estimator_fn, model=None, input_fn=None, model_dir=None, v1_compat=False):
@@ -209,7 +215,7 @@ class TFEstimatorModelBackend(BaseModelBackend):
         return meta
 
     def predict(
-          self, modelname, Xname, rName=None, pure_python=True, **kwargs):
+            self, modelname, Xname, rName=None, pure_python=True, **kwargs):
         import pandas as pd
         model = self.model_store.get(modelname)
         X = self._resolve_input_data('predict', Xname, 'X', **kwargs)
@@ -220,8 +226,8 @@ class TFEstimatorModelBackend(BaseModelBackend):
         return self._prepare_result('predict', result, rName=rName, pure_python=pure_python, **kwargs)
 
     def score(
-          self, modelname, Xname, Yname=None, rName=True, pure_python=True,
-          **kwargs):
+            self, modelname, Xname, Yname=None, rName=True, pure_python=True,
+            **kwargs):
         import pandas as pd
         model = self.model_store.get(modelname)
         X = self.data_store.get(Xname)

--- a/omegaml/backends/tensorflow/tfkeras.py
+++ b/omegaml/backends/tensorflow/tfkeras.py
@@ -5,6 +5,13 @@ from omegaml.util import temp_filename
 
 
 class TensorflowKerasBackend(KerasBackend):
+    """
+    .. versionchanged:: NEXT
+        Only supported for tensorflow <= 2.15 and Python <= 3.11
+
+    .. deprecated:: NEXT
+        Use an object helper or a serializer/loader combination instead.
+    """
     KIND = 'tfkeras.h5'
 
     @classmethod

--- a/omegaml/backends/tensorflow/tfkerassavedmodel.py
+++ b/omegaml/backends/tensorflow/tfkerassavedmodel.py
@@ -4,6 +4,13 @@ from .tfsavedmodel import TensorflowSavedModelBackend
 
 
 class TensorflowKerasSavedModelBackend(TensorflowSavedModelBackend):
+    """
+    .. versionchanged:: NEXT
+        Only supported for tensorflow <= 2.15 and Python <= 3.11
+
+    .. deprecated:: NEXT
+        Use an object helper or a serializer/loader combination instead.
+    """
     KIND = 'tfkeras.savedmodel'
 
     @classmethod

--- a/omegaml/backends/tensorflow/tfsavedmodel.py
+++ b/omegaml/backends/tensorflow/tfsavedmodel.py
@@ -14,6 +14,12 @@ from omegaml.backends.basemodel import BaseModelBackend
 class TensorflowSavedModelPredictor(object):
     """
     A predictor model from a TF SavedModel
+
+    .. versionchanged:: NEXT
+        Only supported for tensorflow <= 2.15 and Python <= 3.11
+
+    .. deprecated:: NEXT
+        Use an object helper or a serializer/loader combination instead.
     """
 
     def __init__(self, model_dir):
@@ -129,7 +135,7 @@ class TensorflowSavedModelBackend(BaseModelBackend):
         return export_dir_base
 
     def predict(
-          self, modelname, Xname, rName=None, pure_python=True, **kwargs):
+            self, modelname, Xname, rName=None, pure_python=True, **kwargs):
         """
         Predict from a SavedModel
 

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -465,7 +465,7 @@ def load_framework_support(vars=globals()):
 
     if OMEGA_DISABLE_FRAMEWORKS:
         return
-    if tensorflow_available():
+    if tensorflow_available(max='2.5'):
         #: tensorflow backend
         # https://stackoverflow.com/a/38645250
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = os.environ.get('TF_CPP_MIN_LOG_LEVEL') or '3'
@@ -475,7 +475,7 @@ def load_framework_support(vars=globals()):
     if module_available('openai'):
         vars['OMEGA_STORE_BACKENDS'].update(vars['OMEGA_STORE_BACKENDS_OPENAI'])
     #: keras backend
-    if keras_available():
+    if keras_available(max='2.0'):
         vars['OMEGA_STORE_BACKENDS'].update(vars['OMEGA_STORE_BACKENDS_KERAS'])
     #: sqlalchemy backend
     if module_available('sqlalchemy'):

--- a/omegaml/notebook/jobschedule.py
+++ b/omegaml/notebook/jobschedule.py
@@ -1,4 +1,5 @@
 import datetime
+
 from celery.schedules import crontab
 from croniter import croniter
 
@@ -116,8 +117,10 @@ class JobSchedule(object):
     @property
     def text(self):
         """ return the human readable representation of the schedule """
-        from cron_descriptor import get_description
-        return get_description(self.cron)
+        from cron_descriptor import get_description, Options
+        options = Options()
+        options.use_24hour_time_format = False
+        return get_description(self.cron, options)
 
     def next_times(self, n=None, last_run=None):
         """ return the n next times of this schedule, staring from the last run

--- a/omegaml/server/dashboard/views/base.py
+++ b/omegaml/server/dashboard/views/base.py
@@ -71,7 +71,7 @@ class BaseView(OmegaViewMixin, FlaskView):
 T = TypeVar('T')
 
 
-def mixin_for(baseclass: Type[T]) -> Type[T]:
+def mixin_for(baseclass: type[T]) -> type[T]:
     """ use this to decorate a mixin class for typehints, keeping the mixin class a subclass of object """
     # https://github.com/python/typing/issues/246
     return object

--- a/omegaml/tests/core/test_datarevision.py
+++ b/omegaml/tests/core/test_datarevision.py
@@ -311,5 +311,5 @@ class DataRevisionMixinTests(OmegaTestMixin, unittest.TestCase):
         om.datasets.put(df_a, 'revtest', append=False)
         with self.assertRaises(ValueError) as cm:
             om.datasets.put(df_a, 'revtest', revisions=True)
-        self.assertEquals(str(cm.exception),
+        self.assertEqual(str(cm.exception),
                           "adding revisions to existing dataset revtest is not supported")

--- a/omegaml/tests/core/test_objhelper.py
+++ b/omegaml/tests/core/test_objhelper.py
@@ -112,7 +112,7 @@ class ObjectHelperTests(OmegaTestMixin, TestCase):
         om.jobs.create(code, 'myjob', helper='myhelper')
         nb = om.jobs.get('myjob')
         self.assertEqual(len(nb.cells), 2)
-        self.assertRegexpMatches(nb.cells[-1]['source'], r'\d{4}-\d{2}-\d{2}.*')
+        self.assertRegex(nb.cells[-1]['source'], r'\d{4}-\d{2}-\d{2}.*')
 
     def test_supports(self):
         """ test using helper selection by supports= conditions """

--- a/omegaml/tests/tensorflow/test_kerasmodel.py
+++ b/omegaml/tests/tensorflow/test_kerasmodel.py
@@ -8,7 +8,7 @@ from omegaml.backends.keras import KerasBackend
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("keras") or module_available("tensorflow.keras"), "keras not available")
+@unittest.skipUnless(module_available("keras", max='2'), "keras not available")
 class KerasBackendTests(TestCase):
     def setUp(self):
         self.om = Omega()
@@ -83,9 +83,3 @@ class KerasBackendTests(TestCase):
         x_test = np.random.random((100, 20))
         result = om.runtime.model('keras-model').predict(x_test).get()
         self.assertEqual(result.shape, (100, 10))
-
-
-
-
-
-

--- a/omegaml/tests/tensorflow/test_protobuf.py
+++ b/omegaml/tests/tensorflow/test_protobuf.py
@@ -9,7 +9,7 @@ from omegaml.tests.util import OmegaTestMixin, tf_perhaps_eager_execution
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow not available")
+@unittest.skipUnless(module_available("tensorflow", max='2.15'), "tensorflow not available")
 class ProtobufDataBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
         self.om = Omega()

--- a/omegaml/tests/tensorflow/test_tfdataset.py
+++ b/omegaml/tests/tensorflow/test_tfdataset.py
@@ -9,7 +9,7 @@ from omegaml.tests.util import tf_perhaps_eager_execution, OmegaTestMixin
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow not available")
+@unittest.skipUnless(module_available("tensorflow", max='2.15'), "tensorflow not available")
 @skip("requires eager mode which must be enabled once for the whole python session")
 class TensorflowDatasetBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
@@ -45,8 +45,3 @@ class TensorflowDatasetBackendTests(OmegaTestMixin, TestCase):
         for img in ds.take(1):
             print(img.numpy())
             break
-
-
-
-
-

--- a/omegaml/tests/tensorflow/test_tfestimator.py
+++ b/omegaml/tests/tensorflow/test_tfestimator.py
@@ -1,7 +1,6 @@
-from unittest import TestCase, skip
-
 import unittest
 from inspect import isfunction
+from unittest import TestCase, skip
 
 from omegaml import Omega
 from omegaml.backends.virtualobj import virtualobj
@@ -55,7 +54,8 @@ def make_input_fn():
 
     return input_fn
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow not available")
+
+@unittest.skipUnless(module_available("tensorflow", max='2.15'), "tensorflow not available")
 class TFEstimatorModelBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
         from omegaml.backends.tensorflow.tfestimatormodel import TFEstimatorModelBackend

--- a/omegaml/tests/tensorflow/test_tfkerasmodel.py
+++ b/omegaml/tests/tensorflow/test_tfkerasmodel.py
@@ -8,7 +8,7 @@ from omegaml.tests.util import OmegaTestMixin, tf_perhaps_eager_execution
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow not available")
+@unittest.skipUnless(module_available("tensorflow", max='2.15'), "tensorflow not available")
 class TensorflowKerasBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
         from omegaml.backends.tensorflow.tfkeras import TensorflowKerasBackend
@@ -107,9 +107,3 @@ class TensorflowKerasBackendTests(OmegaTestMixin, TestCase):
         self.assertIsInstance(model_, TensorflowSavedModelPredictor)
         yhat_ = model_.predict(x_test)
         self.assertTrue(np.allclose(yhat_, yhat))
-
-
-
-
-
-

--- a/omegaml/tests/tensorflow/test_tfsavedmodel.py
+++ b/omegaml/tests/tensorflow/test_tfsavedmodel.py
@@ -6,7 +6,7 @@ from omegaml.tests.util import OmegaTestMixin, tf_in_eager_execution
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow not available")
+@unittest.skipUnless(module_available("tensorflow", max='2.15'), "tensorflow not available")
 class TensorflowSavedModelBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
         from omegaml.backends.tensorflow.tfsavedmodel import TensorflowSavedModelBackend
@@ -82,9 +82,11 @@ class TensorflowSavedModelBackendTests(OmegaTestMixin, TestCase):
             return tf.estimator.export.ServingInputReceiver(features, receiver_tensors)
 
         x_test = np.random.random((100, 20))
+
         def input_fn():
             X = tf.data.Dataset.from_tensor_slices(x_test)
             return X.batch(1)
+
         yhat = [v for v in model.predict(input_fn=input_fn)]
         om.models.put(model, 'estimator-savedmodel',
                       serving_input_fn=serving_input_receiver_fn)
@@ -119,9 +121,11 @@ class TensorflowSavedModelBackendTests(OmegaTestMixin, TestCase):
             return tf.estimator.export.ServingInputReceiver(features, receiver_tensors)
 
         x_test = np.random.random((100, 20))
+
         def input_fn():
             X = tf.data.Dataset.from_tensor_slices(x_test)
             return X.batch(1)
+
         yhat = [v for v in model.predict(input_fn=input_fn)]
         om.models.put(model, 'estimator-savedmodel',
                       serving_input_fn=serving_input_receiver_fn)
@@ -140,6 +144,7 @@ class TensorflowSavedModelBackendTests(OmegaTestMixin, TestCase):
         model = self._build_model()
 
         default_batch_size = 1
+
         def serving_input_receiver_fn():
             placeholder = tf.placeholder(dtype=np.float32,
                                          shape=(default_batch_size, 20),
@@ -147,6 +152,3 @@ class TensorflowSavedModelBackendTests(OmegaTestMixin, TestCase):
             receiver_tensors = {'X_input': placeholder}
             features = {'X_input': placeholder}
             return tf.estimator.export.ServingInputReceiver(features, receiver_tensors)
-
-
-

--- a/omegaml/tests/tensorflow/test_tftracking.py
+++ b/omegaml/tests/tensorflow/test_tftracking.py
@@ -8,7 +8,7 @@ from omegaml.tests.util import OmegaTestMixin
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow is not installed")
+@unittest.skipUnless(module_available("tensorflow", max='2.15'), "tensorflow is not installed")
 class TFCallbackTrackingTestCases(OmegaTestMixin, unittest.TestCase):
     """
     notes on framework versions v.v. tracing

--- a/scripts/docker/test_images_minimal.ini
+++ b/scripts/docker/test_images_minimal.ini
@@ -1,4 +1,14 @@
 #jupyter stacks data science (including R)
+[jdsn313]
+image=quay.io/jupyter/datascience-notebook:python-3.13
+tests=omegaml/tests
+extras=all
+
+[jdsn312]
+image=quay.io/jupyter/datascience-notebook:python-3.12
+tests=omegaml/tests
+extras=all
+
 [jdsn311]
 image=quay.io/jupyter/datascience-notebook:python-3.11
 tests=omegaml/tests

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ dashserve_deps = ['dash>=2.9', 'plotly']
 snowflake_deps = ['snowflake-sqlalchemy']
 jupyter_deps = ['jupyterlab', 'jupyterhub', 'notebook', 'nbclassic']
 mlflow_deps = ['mlflow-skinny>=1.2']
-tf_deps = ['tensorflow>2,<2.16']  # due to 2.16 dropping support for tf-estimators
+tf_deps = ['tensorflow>2']  # due to 2.16 dropping support for tf-estimators
 dev_deps = ['pytest', 'twine', 'flake8', 'mock', 'behave', 'splinter[selenium]', 'ipdb', 'bumpversion', 'pip-tools',
-            'pytest-instafail', 'tox']
+            'pytest-instafail', 'tox', 'ruff']
 # required to avoid backtracking (falling below some versions)
 backtracking_deps = [
     'json5>0.9',


### PR DESCRIPTION
- tensorflow 2.15 / keras 2.x supports up to python 3.11, deprecated
- tensorflow >=2.16 / keras 3.x requires python >= 3.12, deprecated
- use the new object helper to save/load tensorflow and keras models