### PR TITLE
chore: always use croniter with 12hour descriptions

### DIFF
--- a/omegaml/notebook/jobschedule.py
+++ b/omegaml/notebook/jobschedule.py
@@ -1,4 +1,5 @@
 import datetime
+
 from celery.schedules import crontab
 from croniter import croniter
 
@@ -116,8 +117,10 @@ class JobSchedule(object):
     @property
     def text(self):
         """ return the human readable representation of the schedule """
-        from cron_descriptor import get_description
-        return get_description(self.cron)
+        from cron_descriptor import get_description, Options
+        options = Options()
+        options.use_24hour_time_format = False
+        return get_description(self.cron, options)
 
     def next_times(self, n=None, last_run=None):
         """ return the n next times of this schedule, staring from the last run

--- a/omegaml/tests/core/test_datarevision.py
+++ b/omegaml/tests/core/test_datarevision.py
@@ -1,6 +1,7 @@
-import pandas as pd
 import unittest
 from datetime import datetime
+
+import pandas as pd
 from pandas._testing import assert_frame_equal
 
 from omegaml import Omega
@@ -311,5 +312,5 @@ class DataRevisionMixinTests(OmegaTestMixin, unittest.TestCase):
         om.datasets.put(df_a, 'revtest', append=False)
         with self.assertRaises(ValueError) as cm:
             om.datasets.put(df_a, 'revtest', revisions=True)
-        self.assertEquals(str(cm.exception),
-                          "adding revisions to existing dataset revtest is not supported")
+        self.assertEqual(str(cm.exception),
+                         "adding revisions to existing dataset revtest is not supported")


### PR DESCRIPTION
- don't fall back to locale
- keep compatibility with python

includes #562 for job scheduling
- don't fall back to locale
- keep compatibility with python