### PR TITLE
feat: enable more flexible sqlalchemy connection pooling

### DIFF
--- a/omegaml/backends/helpers/odbcpooling.py
+++ b/omegaml/backends/helpers/odbcpooling.py
@@ -1,0 +1,121 @@
+"""
+omegaml object helper for selecting datasets to reset odbc connection pooling
+
+This resolves an issue with low-frequency access to SQL Server causing intermittent connection
+drops. (OperationalError: ('HY000', "[HY000] [Microsoft][ODBC Driver 18 for SQL Server]
+TCP Provider: Error code 0x2b (2) (SQLDriverConnect)"))
+
+Background:
+
+- The ODBC Driver error is due to a rare constellation where the ODBC connection has been idle for
+  longer than 3600 seconds. SQLAlchemy is configured to issue a connection ping (SELECT 1) to validate
+  the connection is still active. However, subsequent queries may still fail due to some network component
+  dropping the connection, despite the successful SELECT 1.
+
+- This helper resets the connection pool on all SQLAlchemy datasets, and ensures a new connection pool
+  is created for matching the prefix filter. It can be adapted to other datasets or other types of filters,
+  if required.
+
+- To include or exclude a specific dataset, within or outside of the prefix filter, set the object's
+  Metadata.attributes['sqlalchemy_clear'] = True | False (where True means to reset the connection pool).
+  False means to reuse the existing connection pool. Defaults to False.
+
+- To change parameters of the connection pool, set helper's Meta.attributes['pool_recycle'] = seconds.
+  To set the prefixes, set helper's meta.attributes['prefixes'] = ['/prefix', ...], or [] to disable keep=False
+
+Args:
+    method (string): 'get', 'put', 'drop', depending on the method called (on.datasets.get/put/drop)
+    meta (Metadata): the metadata of the object
+    store (OmegaStore): the store, here on.dataset
+    backend (BackedBackend): the object's backend instance
+    **kwargs (dict): any other kwargs passed to the on.datasets.get/put/drop method
+
+Returns:
+    result (DataFrame|Connection|None): for method == 'get', the result of the backend.get() call; for
+    all other methods None, the object helper mixin will call the backend directly.
+"""
+import time
+
+from omegaml.backends.virtualobj import virtualobj
+
+
+@virtualobj
+def helper(*args, method=None, meta=None, store=None, backend=None, **kwargs):
+    import omegaml as om
+    on = om.datasets
+    on.logger.debug(f"helper called with {method=} {store=} {backend=} {kwargs=}")
+    # options
+    prefixes = ['/sql']
+    pool_recycle = 1800  # 30 minutes
+
+    def get_helper_config():
+        # get helper config
+        # -- ensure helper metadata can be read ok subsequently, due to metadata caching
+        helper_meta = om.datasets.metadata('.helpers/odbcpooling')
+        helper_meta.gridfile.seek(0) if helper_meta is not None else None
+        # --read config
+        cfg_prefixes = helper_meta.attributes.get('prefixes', prefixes)
+        cfg_pool_recycle = helper_meta.attributes.get('pool_recycle', pool_recycle)
+        return cfg_prefixes, cfg_pool_recycle
+
+    def should_reset_connection_pool():
+        # have already applied the connection pool recycle fix?
+        from omegaml.backends.sqlalchemy import ENGINE_KWARGS
+        return ENGINE_KWARGS.get('pool_recycle', pool_recycle) != pool_recycle
+
+    def reset_connection_pool():
+        # resetting all connections, in all pools
+        from omegaml.backends.sqlalchemy import ENGINE_KWARGS, SQLAlchemyBackend
+        # from omegaml.backends.sqlalchemy import ENGINE_KWARGS, SQLAlchemyBackend
+        # reset sqlalchemy pooling parameters to better defaults
+        # retry to avoid intermittent errors, then rebuild connection pool
+        for i in range(5):
+            try:
+                on.logger.debug('resetting connection pool')
+                # disable pyodbc pooling to avoid pyodbc / sqlalchemy pooling interference
+                import pyodbc
+                pyodbc.pooling = False
+                ENGINE_KWARGS.update(pool_pre_ping=True, pool_recycle=pool_recycle)
+                SQLAlchemyBackend._SQLAlchemyBackend__CNX_CACHE.clear()  # noqa
+                # keep-false clears the sqlalchemy engine pool for matching datasets
+                # -- any future connections will be fresh. We try multiple times to clear caches
+                # -- this adds a small delay on initial connections
+                backend.get(meta.name, keep=False, sql='select 1')
+            except Exception as e:
+                on.logger.error(f'reset_connection_pool() failed on attempt {i} due to {e}')
+                time.sleep(.001)
+            else:
+                break
+
+    def dataset_preping():
+        # on.datasets.get() with implied keep=False to ensure a fresh connection
+        on.logger.debug('resetting odbc pooling for {meta.name}')
+        # usual get, remove any kwargs not recognized by sqlalchemy dataset
+        [kwargs.pop('keep', None) for k in dict(kwargs)
+         if k not in "sql,chunksize,raw,sqlvars,secret,index,keep,lazy,table,trusted".split(',')]
+        # reset connection pool with retry for this dataset, ensure a new connection can be established
+        # since we have a new pool, pre ping is not issued by sqlalchemy, so we do it
+        for i in range(5):
+            try:
+                backend.get(meta.name, keep=False, sql='select 1')
+            except Exception as e:
+                on.logger.error(f'get with fresh connection() on {meta.name} failed on attempt {i} due to {e}')
+            else:
+                break
+
+    prefixes, pool_recycle = get_helper_config()
+    reset_connection_pool() if should_reset_connection_pool() else None
+
+    if method == 'get':
+        if (any(meta.name.startswith(p) for p in prefixes)
+                or meta.attributes.get('sqlalchemy_clear', False)):
+            dataset_preping()
+
+    # returning None triggers the default backend processing
+    return None
+
+
+def install():
+    import omegaml as om
+    # as_source=True ensures this helper works across all Python versions
+    om.datasets.put(helper, 'helpers/odbcpooling', supports='kind:sqlalchemy.*', replace=True, as_source=True)

--- a/omegaml/backends/sqlalchemy.py
+++ b/omegaml/backends/sqlalchemy.py
@@ -1,15 +1,15 @@
+from logging import warning
+
 import logging
 import os
+import sqlalchemy
 import string
 import warnings
 from getpass import getuser
 from hashlib import sha256
-from logging import warning
-from urllib.parse import quote_plus
-
-import sqlalchemy
 from packaging.version import Version
 from sqlalchemy.exc import StatementError
+from urllib.parse import quote_plus
 
 from omegaml.backends.basedata import BaseDataBackend
 from omegaml.util import ProcessLocal, KeepMissing, tqdm_if_interactive, signature
@@ -51,6 +51,19 @@ ENGINE_KWARGS = dict(echo=False, pool_pre_ping=True, pool_recycle=3600)
 # -- pool_recylce=N - do not reuse connections older than N seconds
 
 logger = logging.getLogger(__name__)
+
+try:
+    # disable pydbc pooling in favor of SQLAlchemy pooling, as recommended by sqlalchemy docs
+    # see: https://github.com/mkleehammer/pyodbc/wiki/The-pyodbc-Module#pooling
+    #      https://docs.sqlalchemy.org/en/14/dialects/mssql.html#pyodbc-pooling-connection-close-behavior
+    #      https://docs.sqlalchemy.org/en/20/dialects/mssql.html#pyodbc-pooling-connection-close-behavior
+    import pyodbc
+
+    # we do this here to ensure this is done at the earliest possible time, independent of actual connections
+    # -- this is only effective before the first pyodbc connection
+    pyodbc.pooling = False
+except:
+    pass  # noqa
 
 
 class SQLAlchemyBackend(BaseDataBackend):

--- a/omegaml/backends/virtualobj.py
+++ b/omegaml/backends/virtualobj.py
@@ -1,9 +1,8 @@
 import builtins
+import dill
 import sys
 import types
 import warnings
-
-import dill
 
 from omegaml.backends.basedata import BaseDataBackend
 from omegaml.util import tryOr
@@ -272,6 +271,7 @@ class _DillDip:
         # if isinstance(obj, type):
         #    obj = obj()
         self._check(obj)
+        # FIXME respect as_source before _dill_main
         data = (self._dill_main(obj, **dill_kwargs) or
                 self._dill_types_or_function(obj, as_source=as_source, **dill_kwargs) or
                 self._dill_dill(obj, **dill_kwargs))
@@ -323,6 +323,7 @@ class _DillDip:
     def _dill_source(self, obj, as_source=False, **dill_kwargs):
         # include source code along dill
         try:
+            # FIXME: include python version
             source = dill.source.getsource(obj, lstrip=True)
             source_obj = {'__dipped__': self.__calories,
                           'source': ''.join(source),
@@ -356,6 +357,7 @@ class _DillDip:
         from omegaml.backends.genai.models import GenAIModelHandler, virtual_genai
         # re-compile source obj in __main__
         if self.isdipped(obj):
+            # FIXME and check python version; if not the same don't load the dill object (it may load but still not be executable)
             if 'dill' in obj:
                 try:
                     obj = dill.loads(obj['dill'])

--- a/omegaml/mixins/store/requests.py
+++ b/omegaml/mixins/store/requests.py
@@ -94,6 +94,10 @@ class RequestCache:
             try:
                 # if cached is False, we query the original metadata, yet still cache
                 meta = self._request_cache[name] if cached else _base_meta()
+                # reset gridfile to non-cached state (if it has been read prior)
+                # -- this avoids a later EOF failure when the gridfile is read multiple times in the same request
+                # -- TODO test this works (e.g. with closed gridfiles)
+                meta.gridfile.seek(0) if cached else None
             except:
                 meta = _base_meta()
             # we only cache valid metadata objects


### PR DESCRIPTION
enable more flexible connection pooling
- om.defaults/env SQLALCHEMY_ALWAYS_CACHE=1|0
- om.defaults.SQLALCHEMY_ENGINE_KWARGS=dict(echo=False, pool_preping=True, pool_recycle=3600)

alternatively:
- env SQLALCHEMY_POOL_PREPING=1|0
- env SQLALCHEMY_POOL_REYCLE=N (seconds)

if you can't influence defaults settings, use
- optional odbcpooling helper (omegaml.backends.helpers.odbcpooling), use install()
- configure per datasource by using metadata.attributes.update(pool_recylce=<N seconds>)
- specify for a set of datasources using helper's metadata.attributes.update(prefixes=['prefix/', ...])