### PR TITLE
fix: generic model serializer fails for models that serialize to a directory

### DIFF
--- a/omegaml/backends/genericmodel.py
+++ b/omegaml/backends/genericmodel.py
@@ -32,7 +32,7 @@ class GenericModelBackend(BaseModelBackend):
     KIND = 'python.model'
 
     serializer = lambda store, model, filename, **kwargs: joblib.dump(model, filename)[0]
-    loader = lambda store, infile, filename=None, **kwargs: joblib.load(infile)
+    loader = lambda store, infile, filename=None, **kwargs: joblib.load(infile or filename)
 
     @classmethod
     def supports(cls, obj, name, model_store=None, kind=None, **kwargs):

--- a/omegaml/backends/pytorch.py
+++ b/omegaml/backends/pytorch.py
@@ -16,7 +16,8 @@ class PytorchModelBackend(BaseModelBackend):
     KIND = 'pytorch.pth'
 
     serializer = lambda store, model, filename, **kwargs: torch.save(model, filename, pickle_module=dill)
-    loader = lambda store, infile, filename=None, **kwargs: torch.load(infile, pickle_module=dill, weights_only=False)
+    loader = lambda store, infile=None, filename=None, **kwargs: torch.load(infile, pickle_module=dill,
+                                                                            weights_only=False)
     types = torch.nn.Module
     infer = lambda obj, **kwargs: obj
     reshape = lambda data, **kwargs: torch.tensor(data)

--- a/omegaml/tests/core/test_store.py
+++ b/omegaml/tests/core/test_store.py
@@ -1,20 +1,20 @@
 from __future__ import absolute_import
 
-import gc
-import unittest
-import uuid
-import warnings
-from datetime import timedelta, datetime
-from io import BytesIO
 from pathlib import Path
 from unittest import skip
 
 import dill
+import gc
 import gridfs
 import joblib
 import pandas as pd
 import pymongo
 import smart_open
+import unittest
+import uuid
+import warnings
+from datetime import timedelta, datetime
+from io import BytesIO
 from mongoengine.connection import disconnect
 from mongoengine.errors import DoesNotExist, FieldDoesNotExist
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -1237,7 +1237,7 @@ class StoreTests(unittest.TestCase):
             with open(filename, 'wb') as fout:
                 dill.dump(model, fout)
 
-        loader = lambda store, infile, **kwargs: dill.load(infile)
+        loader = lambda store, infile, filename=None, **kwargs: dill.load(infile)
         # save model
         # -- don't use generic backend
         with self.assertRaises(TypeError):
@@ -1263,7 +1263,7 @@ class StoreTests(unittest.TestCase):
             with smart_open.open(filename, 'wb') as fout:
                 dill.dump(model, fout)
 
-        loader = lambda store, infile, **kwargs: dill.load(infile)
+        loader = lambda store, infile, filename=None, **kwargs: dill.load(infile)
         # -- use generic backend by specifying kind='python.model'
         model = FooModel()
         meta = store.put(model, 'mymodel', kind='python.model', serializer=serializer, uri='/tmp/remotefile.pkl')


### PR DESCRIPTION
- `BaseModelBackend._package_model()` creates a tarfile for all serializer output
- `BaseModelBackend._extract_model()` unpacks tarfile and passes on infile for single-file serializations, the filename=directory for multiple files