### PR TITLE
feat: add indexes specification to datasets

### DIFF
--- a/omegaml/backends/tracking/simple.py
+++ b/omegaml/backends/tracking/simple.py
@@ -1,21 +1,19 @@
+import dill
 import importlib
+import numpy as np
 import os
+import pandas as pd
 import platform
+import pymongo
 import warnings
 from base64 import b64encode, b64decode
 from datetime import date
 from itertools import chain
-from typing import Iterable
-from uuid import uuid4
-
-import dill
-import numpy as np
-import pandas as pd
-import pymongo
-
 from omegaml.backends.tracking.base import TrackingProvider
 from omegaml.documents import Metadata
 from omegaml.util import _raise, ensure_index, batched, signature, tryOr, ensurelist
+from typing import Iterable
+from uuid import uuid4
 
 
 class NoTrackTracker(TrackingProvider):
@@ -576,18 +574,29 @@ class OmegaSimpleTracker(TrackingProvider):
         if not force and self._store.exists(self._data_name):
             return
         coll = self._store.collection(self._data_name)
+        meta = self._store.metadata(self._data_name)
         idxs = [
+            # fast retrieval by run, event, key
             {'data.run': pymongo.ASCENDING, 'data.event': pymongo.ASCENDING, 'data.key': pymongo.ASCENDING,
              'data.experiment': pymongo.ASCENDING},
+            # fast retrieval by dt, event, key
             {'data.dt': pymongo.ASCENDING, 'data.event': pymongo.ASCENDING, 'data.key': pymongo.ASCENDING,
              'data.experiment': pymongo.ASCENDING},
             {'data.dt': pymongo.ASCENDING, 'data.event': pymongo.ASCENDING, 'data.experiment': pymongo.ASCENDING},
             # fast retrieval by event, key, userid across all runs
             {'data.event': pymongo.ASCENDING, 'data.key': pymongo.ASCENDING, 'data.userid': pymongo.ASCENDING,
              'data.experiment': pymongo.ASCENDING},
+            # optimize self._latest_run - this is O(1) retrieval of max(run)
+            {'data.run': pymongo.DESCENDING, 'data.event': pymongo.ASCENDING, 'data.experiment': pymongo.ASCENDING,
+             'create_index_kwargs': dict(partialFilterExpression={"data.event": "start"})},
         ]
+        # add additional indexes from metadata
+        idxs.extend(meta.attributes.get('indexes', [])) if meta else None
+        # TODO use DatasetIndexesMixin
+        # self._store.ensure_indexes(self._data_name, idx_specs=idxs, replace=force)
         for specs in idxs:
-            ensure_index(coll, specs)
+            kwargs = specs.pop('create_index_kwargs', {})
+            ensure_index(coll, specs, **kwargs)
         # self._store.put(coll, self._data_name)
 
     def restore_artifact(self, *args, **kwargs):

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -184,6 +184,7 @@ OMEGA_STORE_MIXINS = [
     'omegaml.mixins.store.extdmeta.SignatureMixin',
     'omegaml.mixins.store.extdmeta.ScriptSignatureMixin',
     'omegaml.mixins.store.extdmeta.ModelSignatureMixin',
+    'omegaml.mixins.store.extdmeta.DatasetIndexesMixin',
     'omegaml.mixins.store.requests.RequestCache',
     'omegaml.mixins.store.passthrough.PassthroughMixin',
     'omegaml.mixins.store.tracking.TrackableMetadataMixin',

--- a/omegaml/mixins/store/extdmeta.py
+++ b/omegaml/mixins/store/extdmeta.py
@@ -1,10 +1,11 @@
+import pymongo
 import string
 import warnings
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
+from copy import deepcopy
 from marshmallow import fields, Schema
-
-from omegaml.util import markup
+from omegaml.util import markup, ensure_index
 
 
 class SignatureMixin:
@@ -497,6 +498,162 @@ class ModelSignatureMixin(SignatureMixin):
 
     def _pre_fit_transform(self, modelname, Xname, **kwargs):
         return self._resolve_dataset_defaults(modelname, Xname, **kwargs)
+
+
+class DatasetIndexesMixin:
+    """Indexes for datasets.
+
+    Enables adding dataset index specifications to a dataset for reference
+    and consistent recreation.
+
+    Metadata:
+        * ``.attributes['indexes']`` → ``{'<key>': <sort order>}``
+
+    .. versionadded:: NEXT
+        Enable consistent indexes specification in metadata.
+    """
+
+    @classmethod
+    def supports(cls, store, **kwargs):
+        """Return True if the store can hold indexed datasets.
+
+        Args:
+            store: Storage backend object that provides a ``prefix`` attribute.
+            **kwargs: Additional keyword arguments (currently ignored).
+
+        Returns:
+            bool: ``True`` when ``store.prefix`` equals ``'data/'``, otherwise
+            ``False``.
+        """
+        return store.prefix in ('data/')
+
+    def link_indexes(self, name, idx_specs):
+        """Add an index specification to a dataset’s metadata.
+
+        The method normalizes ``idx_specs`` (accepting the canonical string
+        representation ``'+colA,-colB'`` or a mapping) and stores the resulting
+        list in ``metadata.attributes['indexes']``.
+
+        Args:
+            name (str): Name of the dataset whose metadata should be updated.
+            idx_specs (str | dict | list[dict]): Index specification(s). Accepted
+                forms:
+
+                * **String** – comma‑separated ``+``, ``-``, ``@`` or ``*`` tokens,
+                  e.g. ``'+date,-price'``.
+                * **Mapping** – ``{field: sort_order}`` where ``sort_order`` is a
+                  MongoDB constant (``pymongo.ASCENDING``,
+                  ``pymongo.DESCENDING`` etc.).
+                * **Iterable of mappings** – a list/tuple of the above.
+
+        Returns:
+            Metadata: The saved metadata object for *name*.
+        """
+        meta = self.metadata(name)
+
+        # Convert canonical string like '+colA,-colB' to a dict.
+        if isinstance(idx_specs, str):
+            mapping = {
+                "+": pymongo.ASCENDING,
+                "-": pymongo.DESCENDING,
+                "@": pymongo.GEO2D,
+                "*": pymongo.GEOSPHERE,
+            }
+            idx_specs = {
+                item[1:]: mapping[item[0]]
+                for item in idx_specs.split(",")
+                if item
+            }
+        # Normalize to a list of dicts.
+        idx_specs = (
+            idx_specs
+            if isinstance(idx_specs, (list, tuple))
+            else [idx_specs]
+        )
+        meta.attributes.setdefault("indexes", [])
+        meta.attributes["indexes"].extend(idx_specs)
+        return meta.save()
+
+    def ensure_indexes(self, name, idx_specs=None, replace=False):
+        """Ensure that the required indexes exist for a dataset.
+
+        If the underlying backend implements its own ``ensure_indexes`` method,
+        that method is delegated to, otherwise MongoDB’s ``create_index`` is
+        used via :func:`ensure_index`. When ``replace`` is ``True`` any existing
+        index with the same name will be dropped and recreated.
+
+        Args:
+            name (str): Dataset name.
+            idx_specs (dict | list[dict] | None, optional): Index specification(s).
+                When omitted, the method reads the specifications from
+                ``metadata.attributes['indexes']``.
+            replace (bool, optional): If ``True`` drop and recreate any existing
+                index with the same definition. Defaults to ``False``.
+
+        Returns:
+            Metadata: Updated metadata after the operation.
+        """
+        meta = self.metadata(name)
+        indexes_specs = idx_specs or meta.attributes.get("indexes")
+        # call backend's method if available
+        backend = self.get_backend(name)
+        if hasattr(backend, "ensure_indexes"):
+            # Backend‑specific implementation.
+            return backend.ensure_indexes(name, specs=indexes_specs)
+        # no backend method, we process
+        coll = self.collection(name)
+        # deepcopy to avoid mutating caller‑provided spec objects.
+        for one_ix_specs in deepcopy(indexes_specs):
+            kwargs = one_ix_specs.pop("create_index_kwargs", {})
+            ensure_index(coll, one_ix_specs, replace=replace, **kwargs)
+        # persist any explicit specifications back to metadata.
+        if idx_specs is not None:
+            self.link_indexes(name, indexes_specs)
+        return meta.save()
+
+    def list_indexes(self, name):
+        """List all indexes defined on a dataset collection.
+
+        Args:
+            name (str): Dataset name.
+
+        Returns:
+            dict: Mapping of ``index_name`` → ``spec_string`` where the spec
+            string uses ``+`` for ascending and ``-`` for descending, e.g.
+            ``'+field1,-field2'``.
+        """
+        index_map = {
+            idx["name"]: ",".join(
+                f"+{k}" if v == 1 else f"-{k}"
+                for k, v in idx["key"].items()
+            )
+            for idx in self.collection(name).list_indexes()
+        }
+        return index_map
+
+    def drop_indexes(self, name, idxname=None):
+        """Drop one or all non‑default indexes from a dataset collection.
+
+        Args:
+            name (str): Dataset name.
+            idxname (str, optional): Specific index name to drop. If omitted,
+                all indexes except the implicit ``_id`` index are removed.
+
+        Returns:
+            Metadata: Metadata after clearing the ``indexes`` attribute.
+        """
+        meta = self.metadata(name)
+        if idxname is None:
+            idx_to_drop = self.list_indexes(name).keys()
+        else:
+            idx_to_drop = [idxname]
+        for idx in idx_to_drop:
+            # Never drop the automatic ``_id`` index.
+            if idx.startswith("_id"):
+                continue
+            self.collection(name).drop_index(idx)
+        meta.attributes["indexes"] = []
+        return meta.save()
 
 
 schema_name = lambda s: getattr(s, '__name__', s.__class__.__name__)

--- a/omegaml/tests/core/test_extdmeta.py
+++ b/omegaml/tests/core/test_extdmeta.py
@@ -5,12 +5,11 @@ import unittest
 from datetime import datetime
 from marshmallow import Schema, fields, ValidationError
 from numpy.testing import assert_array_equal
-from sklearn.linear_model import LinearRegression
-
 from omegaml import Omega
 from omegaml.backends.virtualobj import virtualobj
-from omegaml.mixins.store.extdmeta import SignatureMixin, ModelSignatureMixin, ScriptSignatureMixin
+from omegaml.mixins.store.extdmeta import SignatureMixin, ModelSignatureMixin, ScriptSignatureMixin, DatasetIndexesMixin
 from omegaml.tests.util import OmegaTestMixin
+from sklearn.linear_model import LinearRegression
 
 
 class ExtendedMetadataMixinTests(OmegaTestMixin, unittest.TestCase):
@@ -19,6 +18,7 @@ class ExtendedMetadataMixinTests(OmegaTestMixin, unittest.TestCase):
     def setUp(self):
         om = self.om = Omega()
         om.datasets.register_mixin(SignatureMixin)
+        om.datasets.register_mixin(DatasetIndexesMixin)
         om.models.register_mixin(ModelSignatureMixin)
         om.scripts.register_mixin(ScriptSignatureMixin)
         super().clean()
@@ -386,6 +386,21 @@ class ExtendedMetadataMixinTests(OmegaTestMixin, unittest.TestCase):
         self.assertIn('404', specs['paths']['/api/service/mymodel']['post']['responses'])
         self.assertIn('mymodel_404', specs['definitions'])
         self.assertIn('message', specs['definitions']['mymodel_404']['properties'])
+
+    def test_datasets_idx_specs(self):
+        om = self.om
+        df = pd.DataFrame({'x': range(10), 'y': range(10, 0, -1)})
+        meta = om.datasets.put(df, 'test')
+        om.datasets.link_indexes('test', {'x': +1, 'y': -1})
+        om.datasets.ensure_indexes('test')
+        om.datasets.link_indexes('test', '-x,+y')
+        meta = om.datasets.ensure_indexes('test')
+        self.assertEqual(meta.attributes['indexes'], [{'x': 1, 'y': -1}, {'x': -1, 'y': 1}])
+        indexes = om.datasets.list_indexes('test')
+        self.assertTrue(any(idx in ('+x,-y', '-x,+y') for idx in indexes.values()))
+        om.datasets.drop_indexes('test')
+        indexes = om.datasets.list_indexes('test')
+        self.assertFalse(any(idx in ('+x,-y', '-x,+y') for idx in indexes.values()))
 
 
 @virtualobj


### PR DESCRIPTION
- mixin applies to .datasets
- adds datasets.link_indexes() to add consistent index specifications on datasets
- adds datasets.ensure_indexes() to enable creating indexes on collection-based datasets
- optionally calls backend.ensure_indexes() method instead