### PR TITLE
fix: localize the authentication env to avoid cyclic imports

### DIFF
--- a/omegaml/server/events/ssechat.py
+++ b/omegaml/server/events/ssechat.py
@@ -3,15 +3,13 @@ import json
 import logging
 import threading
 from datetime import timedelta, datetime
+from flask import Response, request, abort, Blueprint, current_app
 from hashlib import pbkdf2_hmac
+from jose import jwe
 from time import sleep
 from uuid import uuid4
 
-from flask import Response, request, abort, Blueprint, current_app
-from jose import jwe
-
 from omegaml.backends.restapi.streamable import StreamableResourceMixin
-from omegaml.client.auth import AuthenticationEnv
 from omegaml.util import utcnow
 
 TIMEOUT = 100  # timeout in seconds
@@ -20,12 +18,15 @@ logger = logging.getLogger(__name__)
 bp = Blueprint('ssechat', __name__)
 context = threading.local()
 
-auth_env = AuthenticationEnv.active()
-
 
 class Streamable(StreamableResourceMixin):
     def __init__(self, om):
         self.om = om
+
+
+def get_auth_env():
+    from omegaml.client.auth import AuthenticationEnv
+    return AuthenticationEnv.active()
 
 
 def authorized(fn):
@@ -111,6 +112,7 @@ def authorized(fn):
             abort(401, description=message)
         # -- establish omega session
         try:
+            auth_env = get_auth_env()
             context.userid = userid
             context.apikey = auth_token
             context.qualifier = payload.get('qualifier')

--- a/omegaml/tests/core/restapi/test_ai_ssechat.py
+++ b/omegaml/tests/core/restapi/test_ai_ssechat.py
@@ -1,12 +1,11 @@
 import json
 import unittest
-from hashlib import pbkdf2_hmac
-from unittest.mock import patch
-from uuid import uuid4
-
 from flask import Flask
+from hashlib import pbkdf2_hmac
 from jose import jwe
 from jose.exceptions import JWEError
+from unittest.mock import patch, MagicMock
+from uuid import uuid4
 
 from omegaml import Omega
 from omegaml.backends.restapi.streamable import StreamableResourceMixin
@@ -165,8 +164,10 @@ class SSEServerTests(OmegaTestMixin, unittest.TestCase):
         for auth_kind in ('Bearer', 'ApiKey'):
             with (self.app.test_client() as client,
                   patch('omegaml.server.events.ssechat.stream_result') as stream_result,
-                  patch('omegaml.server.events.ssechat.auth_env') as auth_env):
-                auth_env.get_omega_from_apikey.side_effect = om
+                  patch('omegaml.server.events.ssechat.get_auth_env') as get_auth_env):
+                auth_env = MagicMock()
+                get_auth_env.return_value = auth_env
+                auth_env.get_omega_from_apikey.return_value = om
                 for k, v in cookies.items():
                     client.set_cookie(k, v)
                 if auth_kind == 'ApiKey':


### PR DESCRIPTION
- authentication env is allocated at run time, not import time
- avoids stale authentication env