### PR TITLE
chore: delay new package upgrades

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
             bash Miniforge3-Linux-x86_64.sh -b
             sudo apt update 
             sudo apt install -y docker-compose
+            # avoid installing packages newer than 7 days ago
+            pip config set global.uploaded_prior_to "$(date -d '7 days ago' -Iseconds --utc)" >/dev/null || true
             pip3 install tox tox-run-before tox-conda
       - run:
           name: Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 	pip install --ignore-installed -U pip
 	pip install -U pytest tox tox-conda tox-run-before
 	[ -z "${RUNTESTS}" ] && (pip install gil && gil clone && pip install -r requirements.dev) || echo "env:RUNTESTS set, using packages from pypi only"
-	pip install ${PIPOPTS} --progress-bar off -e ".[${EXTRAS}]" "${PIPREQ}" --extra-index-url https://download.pytorch.org/whl/cpu
+	pip install ${PIPOPTS} --progress-bar off -e ".[${EXTRAS}]" "${PIPREQ}" --find-links https://download.pytorch.org/whl/cpu
 	(which R && scripts/runtime/setup-r.sh) || echo "R is not installed"
 	scripts/install-oras.sh || echo "oras is not installed"
 

--- a/requirements.dev
+++ b/requirements.dev
@@ -1,5 +1,5 @@
 # cpu-only pytorch
---extra-index-url https://download.pytorch.org/whl/cpu
+--find-links https://download.pytorch.org/whl/cpu
 -e .[all,dev]
 -e ../minibatch[all]
 

--- a/scripts/docker/livetest/Dockerfile
+++ b/scripts/docker/livetest/Dockerfile
@@ -8,7 +8,7 @@ USER root
 WORKDIR /app
 COPY ./packages /var/packages
 RUN  pip install --upgrade pip -q
-RUN  pip install $(find /var/packages -type f -name "*.whl") -i $pypi --extra-index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu --progress-bar off --pre omegaml[dev]
+RUN  pip install $(find /var/packages -type f -name "*.whl") -i $pypi --extra-index-url https://pypi.org/simple --find-links https://download.pytorch.org/whl/cpu --progress-bar off --pre omegaml[dev]
 RUN  ln -fs $(find / -type d -wholename '*/omegaml/tests/features') /app/features && \
      ln -fs $(find /  -name omegaml-tutorial.ipynb 2>/dev/null | head -n1 | xargs dirname) /app/docs
 #ensure PYTHONUSERBASE is created


### PR DESCRIPTION
- in wake of pypi zero-day vulnerarbilities https://cwe.mitre.org/data/definitions/506.html (litellm)
- omega-ml has *not* been affected by litellm issue