### PR TITLE
fix: om.runtime.require(logging=(logger, level)] has no effect on remote runtime

### DIFF
--- a/omegaml/celery_util.py
+++ b/omegaml/celery_util.py
@@ -1,8 +1,7 @@
 import getpass
 import sys
-from contextlib import contextmanager
-
 from celery import Task
+from contextlib import contextmanager
 from kombu.serialization import registry
 from kombu.utils import cached_property
 
@@ -152,7 +151,7 @@ class OmegamlTask(EagerSerializationTaskMixin, Task):
     def logging(self):
         kwargs = self.request.kwargs or {}
         logging = kwargs.get('__logging', False)
-        if isinstance(logging, tuple):
+        if isinstance(logging, (tuple, list)):
             logname, level = logging
             if logname is True:
                 logname = 'root'


### PR DESCRIPTION


- require accepts logging: list|tuple, celery transforms to list before transmitting
- celery task now works with either list|tuple