### PR TITLE
fix: saving tensorflow, tensorflow.keras, keras models fails

### DIFF
--- a/omegaml/backends/keras.py
+++ b/omegaml/backends/keras.py
@@ -19,7 +19,7 @@ class KerasBackend(BaseModelBackend):
             is_keras_native = isinstance(obj, (Sequential, Model))
         return is_tf_keras or is_keras_native
 
-    def _package_model(self, model, key, tmpfn):
+    def _package_model(self, model, key, tmpfn, **kwargs):
         # https://www.tensorflow.org/api_docs/python/tf/keras/models/save_model
         # defaults to h5 since TF 2.x. We keep with h5 for simplicity for now
         import tensorflow as tf
@@ -27,9 +27,9 @@ class KerasBackend(BaseModelBackend):
         model.save(tmpfn, **kwargs)
         return tmpfn
 
-    def _extract_model(self, infile, key, tmpfn):
+    def _extract_model(self, infile, key, tmpfn, **kwargs):
         # override to implement model loading
-        from keras.engine.saving import load_model
+        from keras.src.saving.legacy.save import load_model
         with open(tmpfn, 'wb') as pkgf:
             pkgf.write(infile.read())
         return load_model(tmpfn)
@@ -76,8 +76,8 @@ class KerasBackend(BaseModelBackend):
         return self._prepare_result('predict', result, rName=rName, pure_python=pure_python, **kwargs)
 
     def score(
-          self, modelname, Xname, Yname=None, rName=True, pure_python=True,
-          **kwargs):
+            self, modelname, Xname, Yname=None, rName=True, pure_python=True,
+            **kwargs):
         model = self.get_model(modelname)
         X = self.data_store.get(Xname)
         Y = self.data_store.get(Yname)

--- a/omegaml/backends/tensorflow/tfsavedmodel.py
+++ b/omegaml/backends/tensorflow/tfsavedmodel.py
@@ -1,11 +1,11 @@
-import glob
-import os
-import tempfile
-from shutil import rmtree
 from zipfile import ZipFile, ZIP_DEFLATED
 
+import glob
 import numpy as np
+import os
+import tempfile
 import tensorflow as tf
+from shutil import rmtree
 from tensorflow.python.framework.ops import EagerTensor
 
 from omegaml.backends.basemodel import BaseModelBackend

--- a/omegaml/defaults.py
+++ b/omegaml/defaults.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shutil
 import sys
+import warnings
 
 from omegaml.util import dict_merge, markup, inprogress, tryOr, mlflow_available
 
@@ -467,7 +468,15 @@ def load_framework_support(vars=globals()):
 
     if OMEGA_DISABLE_FRAMEWORKS:
         return
-    if tensorflow_available():
+    #: transformers
+    if module_available('transformers', load=False):
+        # ensure legacy keras using tf-keras module
+        # -- https://github.com/huggingface/transformers/issues/34761
+        os.environ.setdefault('TF_USE_LEGACY_KERAS', "1")
+        if module_available('keras') and not os.environ.get("TF_USE_LEGACY_KERAS") == "1":
+            warnings.warn('transformers requires keras < 3. Set env variable TF_USE_LEGACY_KERAS=1. See'
+                          ' https://github.com/huggingface/transformers/issues/34761 for details')
+    if tensorflow_available(max='2.15', py_max='3.11'):
         #: tensorflow backend
         # https://stackoverflow.com/a/38645250
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = os.environ.get('TF_CPP_MIN_LOG_LEVEL') or '3'
@@ -481,7 +490,7 @@ def load_framework_support(vars=globals()):
             with silence(): import onnxruntime as ort  # noqa
         vars['OMEGA_STORE_BACKENDS'].update(vars['OMEGA_STORE_BACKENDS_OPENAI'])
     #: keras backend
-    if keras_available():
+    if keras_available(max='2.0', py_max='3.11'):
         vars['OMEGA_STORE_BACKENDS'].update(vars['OMEGA_STORE_BACKENDS_KERAS'])
     #: sqlalchemy backend
     if module_available('sqlalchemy'):

--- a/omegaml/tests/tensorflow/test_kerasmodel.py
+++ b/omegaml/tests/tensorflow/test_kerasmodel.py
@@ -1,17 +1,20 @@
-import unittest
 from unittest import TestCase
 
 import numpy as np
+import unittest
 
-from omegaml import Omega
 from omegaml.backends.keras import KerasBackend
+from omegaml.tests.util import OmegaTestMixin
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("keras") or module_available("tensorflow.keras"), "keras not available")
-class KerasBackendTests(TestCase):
+@unittest.skipUnless(
+    module_available("keras", max='2.0', py_max='3.11') or
+    module_available("tensorflow", max='2.15', py_max='3.11'),
+    "keras not available")
+class KerasBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
-        self.om = Omega()
+        super().setUp()
         self.om.models.register_backend(KerasBackend.KIND, KerasBackend)
 
     def _build_model(self, fit=False):
@@ -83,9 +86,3 @@ class KerasBackendTests(TestCase):
         x_test = np.random.random((100, 20))
         result = om.runtime.model('keras-model').predict(x_test).get()
         self.assertEqual(result.shape, (100, 10))
-
-
-
-
-
-

--- a/omegaml/tests/tensorflow/test_tfkerasmodel.py
+++ b/omegaml/tests/tensorflow/test_tfkerasmodel.py
@@ -1,14 +1,16 @@
-import unittest
 from unittest import TestCase
 
 import numpy as np
+import unittest
 
 from omegaml import Omega
 from omegaml.tests.util import OmegaTestMixin, tf_perhaps_eager_execution
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow not available")
+@unittest.skipUnless(module_available("keras", max='2.0', py_max='3.11') or
+                     module_available("tensorflow", max='2.15', py_max='3.11'),
+                     "tensorflow.keras not available")
 class TensorflowKerasBackendTests(OmegaTestMixin, TestCase):
     def setUp(self):
         from omegaml.backends.tensorflow.tfkeras import TensorflowKerasBackend
@@ -107,9 +109,3 @@ class TensorflowKerasBackendTests(OmegaTestMixin, TestCase):
         self.assertIsInstance(model_, TensorflowSavedModelPredictor)
         yhat_ = model_.predict(x_test)
         self.assertTrue(np.allclose(yhat_, yhat))
-
-
-
-
-
-

--- a/omegaml/tests/tensorflow/test_tftracking.py
+++ b/omegaml/tests/tensorflow/test_tftracking.py
@@ -1,6 +1,5 @@
-import unittest
-
 import pandas as pd
+import unittest
 
 from omegaml import Omega
 from omegaml.backends.tracking.experiment import ExperimentBackend
@@ -8,7 +7,9 @@ from omegaml.tests.util import OmegaTestMixin
 from omegaml.util import module_available
 
 
-@unittest.skipUnless(module_available("tensorflow"), "tensorflow is not installed")
+@unittest.skipUnless(
+    module_available("tensorflow", max='2.15', py_max='3.11'),
+    "keras not available")
 class TFCallbackTrackingTestCases(OmegaTestMixin, unittest.TestCase):
     """
     notes on framework versions v.v. tracing

--- a/omegaml/util.py
+++ b/omegaml/util.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from importlib import import_module
 from pathlib import Path
 
+import importlib
 import json
 import logging
 import os
@@ -14,7 +15,6 @@ import validators
 import warnings
 from base64 import b64encode
 from bson import ObjectId
-from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, date, timezone
 from hashlib import sha256
@@ -631,30 +631,55 @@ def ignorewarnings(fn):
 
 
 @ignorewarnings
-def module_available(modname):
+def module_available(modname, min=None, max=None, load=True, py_min=None, py_max=None):
+    from importlib.metadata import version
+    from packaging.version import Version
     try:
-        import_module(modname)
-    except:
+        if load:
+            import_module(modname)
+        elif importlib.util.find_spec(modname) is None:
+            raise ModuleNotFoundError(modname)
+    except (TypeError, ModuleNotFoundError) as e:
         return False
+    if py_min or py_max or min or max:
+        try:
+            mod_version = version(modname)
+            py_version = f'{sys.version_info.major}.{sys.version_info.minor}'
+            min_ok = Version(mod_version) >= Version(min) if min else True
+            max_ok = Version(mod_version) <= Version(max) if max else True
+            py_min_ok = Version(py_version) >= Version(py_min) if py_min else True
+            py_max_ok = Version(py_version) <= Version(py_max) if py_max else True
+        except Exception as e:
+            logger.warning(f'version check for {modname=} {min=} {max} failed due to {e}')
+            return False
+        else:
+            min = min or 'any'
+            max = max or 'any'
+            py_min = py_min or 'any'
+            py_max = py_max or 'any'
+            if any(bool(v) is False for v in (min_ok, max_ok, py_min_ok, py_max_ok)):
+                logger.warning((f'require {modname}>={min},<={max}, have {modname}=={mod_version} Python=={py_version}.'
+                                f'Use a model helper for {modname} models.'))
+            return all(v for v in (min_ok, max_ok, py_min_ok, py_max_ok))
     return True
 
 
-def tensorflow_available():
+def tensorflow_available(min=None, max=None, py_min=None, py_max=None):
     # https://stackoverflow.com/a/38645250
     os.environ['TF_CPP_MIN_LOG_LEVEL'] = os.environ.get('TF_CPP_MIN_LOG_LEVEL') or '3'
     logging.getLogger('tensorflow').setLevel(logging.ERROR)
-    return module_available('tensorflow')
+    return module_available('tensorflow', min=min, max=max, py_min=py_min, py_max=py_max)
 
 
-def keras_available():
-    return module_available('keras')
+def keras_available(min=None, max=None, py_min=None, py_max=None):
+    return module_available('keras', min=min, max=max, py_min=py_min, py_max=py_max)
 
 
-def mlflow_available():
+def mlflow_available(min=None, max=None, py_min=None, py_max=None):
     # -- ignore pydantic warning
     # -- TODO remove this once mlflow has fixed pydantic v2 migration issue
     # see https://github.com/mlflow/mlflow/pull/13023
-    available = module_available('mlflow')
+    available = module_available('mlflow', min=min, max=max, py_min=py_min, py_max=py_max)
     return available
 
 
@@ -830,6 +855,7 @@ def base_loader(_base_config):
 
 from io import StringIO
 
+from contextlib import contextmanager
 import re
 
 


### PR DESCRIPTION
- supporting up to tensorflow 2.15, keras 2.0 with python <= 3.11
- use an object helper with custom serializer/loader for tensorflow > 2.15, keras > 2.0, python >= 3.12