### PR TITLE
feat: enable oci registry credentials placeholders

### DIFF
--- a/omegaml/backends/basecommon.py
+++ b/omegaml/backends/basecommon.py
@@ -1,9 +1,12 @@
-import os
 from pathlib import Path
+
+import os
+import smart_open
+from getpass import getuser
+from mongoengine import GridFSProxy
 from warnings import warn
 
-import smart_open
-from mongoengine import GridFSProxy
+from omegaml.util import KeepMissing
 
 
 class BackendBaseCommon:
@@ -161,3 +164,23 @@ class BackendBaseCommon:
     def _call_handler(self):
         # by default the data store handles _pre and _post methods in self.perform()
         return self.data_store
+
+    def _resolve_placeholders(self, creds, secrets=None):
+        """ resolve placeholders in a uri or other string with secrets obtained from env and om.defaults
+
+        Will replace all {placeholders} from om.defaults and the os environment, in that order. env variables
+        are only used if om.defaults.OMEGA_ALLOW_ENV_CONFIG is True.
+
+        Args:
+            creds (str): the string containing placeholders
+            secrets (dict): optional, additional secrets
+
+        Returns:
+            str: resolved creds string
+        """
+        values = ({k: v for k, v in os.environ.items() if k.isupper() and isinstance(v, (str, bytes))}
+                  if self.data_store.defaults.OMEGA_ALLOW_ENV_CONFIG else dict())
+        values.update(**self.data_store.defaults)
+        values.update(secrets or {})
+        user = getattr(self.data_store.defaults, 'OMEGA_USERID', getuser())
+        return creds.format_map(KeepMissing({**values, "userid": user}))

--- a/omegaml/backends/repository/basereg.py
+++ b/omegaml/backends/repository/basereg.py
@@ -7,10 +7,11 @@ from omegaml.util import tryOr
 
 
 class ArtifactRepository:
-    def __init__(self, url, repo=None, namespace=None):
+    def __init__(self, url, repo=None, namespace=None, auth=None):
         self.url = url
         self.repo = repo
         self.namespace = namespace
+        self.auth = auth
 
     def login(self, user, token):
         raise NotImplementedError

--- a/omegaml/backends/repository/ocireg.py
+++ b/omegaml/backends/repository/ocireg.py
@@ -26,7 +26,7 @@ class OCIRegistryBackend(BaseModelBackend):
 
     @classmethod
     def supports(self, obj, name, **kwargs):
-        return str(obj).startswith('oci://') or str(obj).startswith('ocidir://')
+        return any(str(obj).startswith(prefix) for prefix in ('oci://', 'ocidir://', 'file://'))
 
     def put(self, obj, name, asname=None, **kwargs):
         """ store a reference to an oci registry
@@ -79,4 +79,5 @@ class OCIRegistryBackend(BaseModelBackend):
     def _get_registry(self, meta, image=None):
         # TODO resolve placeholders
         url = meta.kind_meta['url']
+        url = self._resolve_placeholders(url)
         return OrasOciRegistry(url, repo=image)

--- a/omegaml/backends/repository/orasreg.py
+++ b/omegaml/backends/repository/orasreg.py
@@ -1,9 +1,10 @@
+from pathlib import Path
+
 import json
 import logging
 import os
 import shutil
 import tarfile
-from pathlib import Path
 from urllib.parse import urlparse
 
 from omegaml.backends.repository.basereg import ArtifactRepository, c, f
@@ -32,27 +33,28 @@ class OrasOciRegistry(ArtifactRepository):
         reg.add('/path/to/file')
         reg.add(['/path/to/file1', '/path/to/file2'])
         reg.add('/path/to/dir')
+
+    .. versionchanged:: NEXT
+        reg.url now includes the protocol oci:// or ocidir://, if specified. use reg.uri
+        to get back the path without protocol
     """
 
     def __init__(self, url, repo=None, namespace=None):
-        protocol, _url, _namespace, image, tag = parse_ociuri(url)
+        protocol, _url, _namespace, image, tag, auth = parse_ociuri(url)
         repo = repo or (f'{image}:{tag}' if image and tag else None)
-        url = str(url)  # allow for url:Path
+        url = str(_url)  # allow for url:Path
         url = url.replace(f'/{image}', '').replace(f':{tag}', '') if (image or tag) else url
-        if protocol == 'ocidir':
-            url = Path(url.replace('ocidir://', ''))
-            url.mkdir(parents=True, exist_ok=True)
-        super().__init__(url, repo=repo, namespace=namespace)
+        super().__init__(url, repo=repo, namespace=namespace, auth=auth)
         self.cache = Path('/tmp') / '.oras' / 'cache'
         os.environ.setdefault('ORAS_CACHE', str(self.cache))
-
-    def logging(self):
-        """ this """
-        print()
 
     def __repr__(self):
         """Return a short representation showing the registry URL and repo."""
         return f'OCIRegistry({self.url}/{self.repo})'
+
+    def _ensure_login(self):
+        if self.auth:
+            self.login(*self.auth)
 
     def login(self, user, token):
         """Log in to the registry using oras.
@@ -62,16 +64,26 @@ class OrasOciRegistry(ArtifactRepository):
         cmd = f"login {self.url} -u {user} --password {token}"
         self._oras(cmd)  # subprocess.run wrapper, no output expected
 
-    def ocidir(self, url=None, opt='--oci-layout'):
-        """Return the CLI option for local OCI layout if the URL is a path.
+    def ociurl(self, url=None, dir_opt='--oci-layout'):
+        """Return the correct cli options for the oras command
 
         Args:
-            opt (str|bool): Option string to return when URL points to a filesystem path.
+            dir_opt (str|bool): Option string to return when URL points to a filesystem path.
 
         Returns:
-            str: opt if the url exists as a filesystem path, otherwise empty string.
+            str: the url as required for the oras command, prefixed with appropriate options
         """
-        return opt if Path(url or self.url).exists() else ''
+        if url.startswith('ocidir://') or url.startswith('oci:///') or url.startswith('file://'):
+            url = Path(url.replace('ocidir://', ''))
+            url.mkdir(parents=True, exist_ok=True)
+        elif url.startswith('oci://'):
+            url = url.replace('oci://', '')
+            dir_opt = ''
+        return f'{dir_opt} {url}' if Path(url or self.url).exists() else url
+
+    @property
+    def uri(self):
+        return self.url.replace('oci://', '').replace('ocidir://', '')
 
     def create(self, repo=None, exists_ok=False):
         """Create an (empty) repository on the registry.
@@ -91,7 +103,7 @@ class OrasOciRegistry(ArtifactRepository):
             raise ValueError(f'{self.url}/{repo} already exists')
         if not exists:
             self._validate('repo', **x(locals()))
-            self._oras((f'push {self.ocidir()} {self.url}/{repo} '
+            self._oras((f'push {self.ociurl(self.url)}/{repo} '
                         f'--config /dev/null:application/vnd.oci.image.config.v1+json --format json'))
         return self.manifest(repo)
 
@@ -126,7 +138,7 @@ class OrasOciRegistry(ArtifactRepository):
             paths[i] = f'{paths[i]}:{t}' if t else paths[i]
         paths_to_add = ' '.join(str(p) for p in paths)
         # oras push will replace any previously existing manifest for the same repo:tag
-        cmd = f"push {self.ocidir()} {self.url}/{repo_path} {paths_to_add} --format json"
+        cmd = f"push {self.ociurl(self.url)}/{repo_path} {paths_to_add} --format json"
         output = self._oras(cmd)  # No output expected
         result = output | f(json.loads)
         return result
@@ -145,19 +157,20 @@ class OrasOciRegistry(ArtifactRepository):
         repo = repo or self.repo
         exists = tryOr(lambda: len(self.tags(repo)) > 0, False)
         self._validate('repo', **x(locals()))
+        self._ensure_login()
         drepo = repo.split(':')[0]
         if exists:
             if not digest:
                 self._validate('url', 'repo', **x(locals()))
                 for artifact in self.artifacts(repo=repo):
                     digest = artifact['digest']
-                    cmd = f'blob delete --force {self.ocidir()} {self.url}/{drepo}@{digest}'
+                    cmd = f'blob delete --force {self.ociurl(self.url)}/{drepo}@{digest}'
                     self._oras(cmd)
 
-                cmd = f'manifest delete --force {self.ocidir()} {self.url}/{repo}'
+                cmd = f'manifest delete --force {self.ociurl(self.url)}/{repo}'
                 self._oras(cmd)
             else:
-                cmd = f'blob delete --force {self.ocidir()} {self.url}/{drepo}@{digest}'
+                cmd = f'blob delete --force {self.ociurl(self.url)}/{drepo}@{digest}'
                 self._oras(cmd)
         elif not force:
             raise ValueError(f'{repo} does not exist (no tags)')
@@ -203,7 +216,7 @@ class OrasOciRegistry(ArtifactRepository):
                 is_tar = False
                 is_gzip = False
                 filename = lpath / Path(a.get('annotations', {}).get('org.opencontainers.image.title')).name
-            cmd = f"blob fetch {self.ocidir()} -o {filename} {self.url}/{repo_path}@{digest}"
+            cmd = f"blob fetch -o {filename} {self.ociurl(self.url)}/{repo_path}@{digest}"
             self._oras(cmd)
             if is_tar:
                 # extract tar blobs into destination directory
@@ -233,7 +246,8 @@ class OrasOciRegistry(ArtifactRepository):
         """
         repo = repo or self.repo
         self._validate('repo', **x(locals()))
-        cmd = f"manifest fetch {self.ocidir()} {self.url}/{repo}"
+        self._ensure_login()
+        cmd = f"manifest fetch {self.ociurl(self.url)}/{repo}"
         output = self._oras(cmd) | f(json.loads)
         return output
 
@@ -264,7 +278,8 @@ class OrasOciRegistry(ArtifactRepository):
         repo = repo or self.repo
         repo = repo.split(':')[0]
         self._validate('repo', **x(locals()))
-        cmd = f'repo tags {self.ocidir()} {self.url}/{repo} --format json'
+        self._ensure_login()
+        cmd = f'repo tags {self.ociurl(self.url)}/{repo} --format json'
         output = self._oras(cmd) | f(json.loads)
         return output['tags']
 
@@ -280,6 +295,7 @@ class OrasOciRegistry(ArtifactRepository):
         """
         repo_path = repo if repo else self.repo
         self._validate('repo', **x(locals()))
+        self._ensure_login()
         cmd = f"manifest fetch {self.url}/{repo_path}@{digest}"
         output = self._oras(cmd).decode('utf-8')
         return output
@@ -374,10 +390,10 @@ def parse_ociuri(ociuri):
     # parse ociuri
     ociuri = f'{implied_scheme}://{ociuri}' if not valid_uri else ociuri
     parsed = urlparse(ociuri)
-    if parsed.scheme in ('file://', 'ocidir'):
+    if parsed.scheme in ('file', 'ocidir'):
         # ocidir:///path/to/registry/image:tag
         # ocidir:///path/to/registry/ns/namespace/image:tag
-        protocol = 'ocidir'
+        protocol = parsed.scheme
         ocidir = Path(parsed.path)
         image, tag = ocidir.name.split(':') if ':' in ocidir.name else ('', 'latest')
         if '/ns/' in parsed.path:
@@ -386,18 +402,29 @@ def parse_ociuri(ociuri):
         else:
             url, namespace = str(ocidir.parent if image else ocidir), ''
         tag = tag if image else ''
-    else:
+        auth = None
+        url = f'{protocol}://{url}' + (f'/ns/{namespace}' if namespace else '')
+    elif parsed.scheme in ('oci',):
         # oci://registry.com/namespace/image:tag
-        protocol = 'oci'
+        protocol = parsed.scheme
+        # get netloc without userid:password
+        port = f':{parsed.port}' if parsed.port is not None else ''
+        bare_netloc = parsed.hostname + port
+        # prepare credentials
+        auth = parsed.username, parsed.password if parsed.username else None
+        # get account/repo/image:tag
         parts = parsed.path.lstrip('/').split('/')
-        url = parsed.netloc
         if ':' in parts[0]:
             namespace, image = ('', parts[0])
         else:
             namespace, image = (parts[0], '/'.join(parts[1:]))
         image, tag = image.split(':') if ':' in image else (image, 'latest')
         tag = tag if image else ''
-    return protocol, url, namespace, image, tag
+        # rebuild canonical url
+        url = f'{protocol}://{bare_netloc}' + (f'/{namespace}' if namespace else '')
+    else:
+        raise ValueError(f'cannot parse {ociuri}, only protocols oci://, ocidir://, file:// are supported')
+    return protocol, url, namespace, image, tag, auth
 
 
 if __name__ == '__main__':

--- a/omegaml/tests/repository/test_ocireg.py
+++ b/omegaml/tests/repository/test_ocireg.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+from unittest import TestCase, skipUnless, skip
+
+import os
 import shutil
 import unittest
 from shutil import rmtree
-from unittest import TestCase, skipUnless, skip
-
 from sklearn.linear_model import LinearRegression, LogisticRegression
 
 from omegaml import Omega
@@ -118,27 +120,27 @@ class TestOCIRegistryBackend(OmegaTestMixin, TestCase):
         om.models.put('ocidir:///tmp/registry', 'ocireg')
         reg = om.models.get('ocireg')
         self.assertIsInstance(reg, OrasOciRegistry)
-        self.assertEqual(str(reg.url), '/tmp/registry')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/registry')
         self.assertEqual(reg.repo, None)
         # -- image on get
         reg = om.models.get('ocireg', image='myimage:latest')
-        self.assertEqual(str(reg.url), '/tmp/registry')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/registry')
         self.assertEqual(reg.repo, 'myimage:latest')
         # -- with image
         om.models.put('ocidir:///tmp/registry/myimage:latest', 'ocireg', replace=True)
         reg = om.models.get('ocireg')
         self.assertIsInstance(reg, OrasOciRegistry)
-        self.assertEqual(str(reg.url), '/tmp/registry')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/registry')
         self.assertEqual(reg.repo, 'myimage:latest')
         # -- no image with a long registry path
         om.models.put('ocidir:///tmp/data/artifacts/registry', 'ocireg', replace=True)
         reg = om.models.get('ocireg')
         self.assertIsInstance(reg, OrasOciRegistry)
-        self.assertEqual(str(reg.url), '/tmp/data/artifacts/registry')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/data/artifacts/registry')
         self.assertEqual(reg.repo, None)
         # -- image on get
         reg = om.models.get('ocireg', image='myimage:latest')
-        self.assertEqual(str(reg.url), '/tmp/data/artifacts/registry')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/data/artifacts/registry')
         self.assertEqual(reg.repo, 'myimage:latest')
 
     def test_putget_ocidir_namespaced(self):
@@ -147,27 +149,27 @@ class TestOCIRegistryBackend(OmegaTestMixin, TestCase):
         om.models.put('ocidir:///tmp/registry/ns/namespace', 'ocireg')
         reg = om.models.get('ocireg')
         self.assertIsInstance(reg, OrasOciRegistry)
-        self.assertEqual(str(reg.url), '/tmp/registry/ns/namespace')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/registry/ns/namespace')
         self.assertEqual(reg.repo, None)
         # -- image on get
         reg = om.models.get('ocireg', image='myimage:latest')
-        self.assertEqual(str(reg.url), '/tmp/registry/ns/namespace')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/registry/ns/namespace')
         self.assertEqual(reg.repo, 'myimage:latest')
         # -- with image
         om.models.put('ocidir:///tmp/registry/ns/namespace/myimage:latest', 'ocireg', replace=True)
         reg = om.models.get('ocireg')
         self.assertIsInstance(reg, OrasOciRegistry)
-        self.assertEqual(str(reg.url), '/tmp/registry/ns/namespace')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/registry/ns/namespace')
         self.assertEqual(reg.repo, 'myimage:latest')
         # -- no image with a long registry path
         om.models.put('ocidir:///tmp/data/artifacts/registry/ns/namespace', 'ocireg', replace=True)
         reg = om.models.get('ocireg')
         self.assertIsInstance(reg, OrasOciRegistry)
-        self.assertEqual(str(reg.url), '/tmp/data/artifacts/registry/ns/namespace')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/data/artifacts/registry/ns/namespace')
         self.assertEqual(reg.repo, None)
         # -- image on get
         reg = om.models.get('ocireg', image='myimage:latest')
-        self.assertEqual(str(reg.url), '/tmp/data/artifacts/registry/ns/namespace')
+        self.assertEqual(str(reg.url), 'ocidir:///tmp/data/artifacts/registry/ns/namespace')
         self.assertEqual(reg.repo, 'myimage:latest')
 
     def test_putget_model(self):
@@ -188,6 +190,24 @@ class TestOCIRegistryBackend(OmegaTestMixin, TestCase):
         model = om.models.get('regmodel')
         self.assertIsInstance(model, LinearRegression)
 
+    @skip('shall be resolved by vllm support')
+    def test_putget_directories(self):
+        import omegaml
+        om = self.om
+        # create an empty oci registry
+        rmtree('/tmp/registry', ignore_errors=True)
+        om.models.put('ocidir:///tmp/registry', 'ocireg')
+        # save a complete directory, zip up
+        # -- expect to store a zip file
+        basedir = Path(omegaml.__file__).parent / 'example' / 'demo'
+        meta = om.models.put(basedir, 'myfile', repo='ocireg')
+        repo = om.models.get('ocireg')
+        print(repo.artifacts('myfile:latest'))
+        # get back
+        extracted = om.models.get('myfile')
+        self.assertTrue(extracted.is_dir())
+        self.assertTrue((extracted / 'demo').is_dir())
+
     @skip("TODO not currently supported")
     def test_putget_multimodels(self):
         om = self.om
@@ -205,6 +225,17 @@ class TestOCIRegistryBackend(OmegaTestMixin, TestCase):
             self.assertEqual(meta.gridfile.read(), None)
         reg = om.models.get('ocireg')
         self.assertEqual(len(reg.artifacts('myimage:latest')), 2)
+
+    def test_resolve_uri_placeholders(self):
+        om = self.om
+        os.environ.update(
+            OMEGA_GHCR_USERID='myuser',
+            OMEGA_GHCR_APIKEY='myapikey',
+        )
+        om.models.put('oci://{OMEGA_GHCR_USERID}:{OMEGA_GHCR_APIKEY}@ghcr.io', 'ocireg')
+        reg = om.models.get('ocireg')
+        self.assertEqual(reg.url, 'oci://ghcr.io')
+        self.assertEqual(reg.auth, ('myuser', 'myapikey'))
 
 
 if __name__ == '__main__':

--- a/omegaml/tests/repository/test_orasreg.py
+++ b/omegaml/tests/repository/test_orasreg.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+from unittest import skipUnless
+
 import shutil
 import unittest
-from pathlib import Path
 from tempfile import mkdtemp
-from unittest import skipUnless
+from unittest.mock import patch
 
 from omegaml.backends.repository.basereg import chdir
 from omegaml.backends.repository.orasreg import OrasOciRegistry, parse_ociuri
@@ -49,57 +51,57 @@ class TestOrasRegistry(unittest.TestCase):
     def test_parse_ociuri(self):
         # full spec
         url = 'oci://ghcr.io/user/myimage:tag'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'oci')
-        self.assertEqual(url, 'ghcr.io')
+        self.assertEqual(url, 'oci://ghcr.io/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, 'myimage')
         self.assertEqual(tag, 'tag')
         # registry only
         url = 'oci://ghcr.io'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'oci')
-        self.assertEqual(url, 'ghcr.io')
+        self.assertEqual(url, 'oci://ghcr.io')
         self.assertEqual(namespace, '')
         self.assertEqual(image, '')
         self.assertEqual(tag, '')
         # registry without namespace, image
         url = 'oci://ghcr.io/myimage:tag'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'oci')
-        self.assertEqual(url, 'ghcr.io')
+        self.assertEqual(url, 'oci://ghcr.io')
         self.assertEqual(namespace, '')
         self.assertEqual(image, 'myimage')
         self.assertEqual(tag, 'tag')
         # registry with namespace
         url = 'oci://ghcr.io/user'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'oci')
-        self.assertEqual(url, 'ghcr.io')
+        self.assertEqual(url, 'oci://ghcr.io/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, '')
         self.assertEqual(tag, '')
         # registry with namespace and image
         url = 'oci://ghcr.io/user/image'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'oci')
-        self.assertEqual(url, 'ghcr.io')
+        self.assertEqual(url, 'oci://ghcr.io/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, 'image')
         self.assertEqual(tag, 'latest')
         # implied oci:// without namespace, with image
         url = 'ghcr.io/image:latest'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'oci')
-        self.assertEqual(url, 'ghcr.io')
+        self.assertEqual(url, 'oci://ghcr.io')
         self.assertEqual(namespace, '')
         self.assertEqual(image, 'image')
         self.assertEqual(tag, 'latest')
         # implied oci:// with namespace and image
         url = 'ghcr.io/user/image'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'oci')
-        self.assertEqual(url, 'ghcr.io')
+        self.assertEqual(url, 'oci://ghcr.io/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, 'image')
         self.assertEqual(tag, 'latest')
@@ -107,49 +109,49 @@ class TestOrasRegistry(unittest.TestCase):
     def test_parse_ociuri_dir(self):
         # full spec
         url = 'ocidir:///tmp/registry/ns/user/myimage:tag'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'ocidir')
-        self.assertEqual(url, '/tmp/registry')
+        self.assertEqual(url, 'ocidir:///tmp/registry/ns/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, 'myimage')
         self.assertEqual(tag, 'tag')
         # registry only
         url = 'ocidir:///tmp/registry'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'ocidir')
-        self.assertEqual(url, '/tmp/registry')
+        self.assertEqual(url, 'ocidir:///tmp/registry')
         self.assertEqual(namespace, '')
         self.assertEqual(image, '')
         self.assertEqual(tag, '')
         # registry without namespace, image
         url = 'ocidir:///tmp/registry/myimage:tag'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'ocidir')
-        self.assertEqual(url, '/tmp/registry')
+        self.assertEqual(url, 'ocidir:///tmp/registry')
         self.assertEqual(namespace, '')
         self.assertEqual(image, 'myimage')
         self.assertEqual(tag, 'tag')
         # registry with namespace
         url = 'ocidir:///tmp/registry/ns/user'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'ocidir')
-        self.assertEqual(url, '/tmp/registry')
+        self.assertEqual(url, 'ocidir:///tmp/registry/ns/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, '')
         self.assertEqual(tag, '')
         # registry with namespace and image
         url = 'ocidir:///tmp/registry/ns/user/myimage'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'ocidir')
-        self.assertEqual(url, '/tmp/registry')
+        self.assertEqual(url, 'ocidir:///tmp/registry/ns/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, 'myimage')
         self.assertEqual(tag, 'latest')
         # just a path
         url = '/tmp/registry/ns/user/myimage'
-        protocol, url, namespace, image, tag = parse_ociuri(url)
+        protocol, url, namespace, image, tag, auth = parse_ociuri(url)
         self.assertEqual(protocol, 'ocidir')
-        self.assertEqual(url, '/tmp/registry')
+        self.assertEqual(url, 'ocidir:///tmp/registry/ns/user')
         self.assertEqual(namespace, 'user')
         self.assertEqual(image, 'myimage')
         self.assertEqual(tag, 'latest')
@@ -170,8 +172,8 @@ class TestOrasRegistry(unittest.TestCase):
         rpath = self.tmppath
         lpath = rpath / 'ns' / 'myspace' / 'myimage'
         shutil.rmtree(rpath) if rpath.exists() else None
-        reg = OrasOciRegistry(lpath, 'fooimage:scratch')
-        self.assertEqual(reg.url, rpath / 'ns' / 'myspace')
+        reg = OrasOciRegistry(f'file://{lpath}', 'fooimage:scratch')
+        self.assertEqual(reg.url, 'file://' + str(rpath / 'ns' / 'myspace'))
         self.assertEqual(reg.repo, 'fooimage:scratch')
         reg.create()
         artifacts = reg.artifacts()
@@ -247,6 +249,16 @@ class TestOrasRegistry(unittest.TestCase):
         self.assertTrue((epath / 'files' / 'myfile.txt').exists())
         self.assertTrue((epath / 'files' / 'otherfile.txt').exists())
         self.assertTrue((epath / 'readme.txt').exists())
+
+    def test_ociuri_with_credentials(self):
+        reg = OrasOciRegistry('oci://myuser:mykey@ghcr.io', 'orasimage:test')
+        self.assertEqual(reg.url, 'oci://ghcr.io')
+        self.assertEqual(reg.auth, ('myuser', 'mykey'))
+        with (patch.object(reg, 'login') as mock_login,
+              patch.object(reg, '_oras') as mock_oras):
+            reg.manifest()
+            mock_login.assert_called_with('myuser', 'mykey')
+            mock_oras.assert_called_once()
 
     def _make_files(self, rpath):
         subdir = rpath / 'myfiles'

--- a/omegaml/tests/util.py
+++ b/omegaml/tests/util.py
@@ -1,9 +1,9 @@
+from http import HTTPStatus
+
 import logging
 import os
 import sys
 import warnings
-from http import HTTPStatus
-
 from mongoengine import disconnect
 
 from omegaml import Omega


### PR DESCRIPTION
- enable placeholders in oci urls
- om.models.put('oci://{USERID}:{PASSWORD}@example.com/registry', 'ocireg')