### PR TITLE
feat: enable local=path storing of model files

### DIFF
--- a/omegaml/backends/rawfiles.py
+++ b/omegaml/backends/rawfiles.py
@@ -1,8 +1,13 @@
+from os.path import dirname
+from pathlib import Path
+
 import io
+import logging
 import os
 from os.path import dirname, basename
 
 import smart_open
+import zipfile
 
 from omegaml.backends.basedata import BaseDataBackend
 
@@ -10,6 +15,8 @@ try:
     from smart_open import open
 except:
     pass
+
+logger = logging.getLogger(__name__)
 
 
 class PythonRawFileBackend(BaseDataBackend):
@@ -39,7 +46,8 @@ class PythonRawFileBackend(BaseDataBackend):
             return False
         return True
 
-    def get(self, name, local=None, mode='wb', open_kwargs=None, chunksize=None, uri=None, **kwargs):
+    def get(self, name, local=None, mode='wb', open_kwargs=None, chunksize=None, uri=None, extract=None, replace=False,
+            **kwargs):
         """
         get a stored file as a file-like object with binary contents or a local file
 
@@ -47,11 +55,17 @@ class PythonRawFileBackend(BaseDataBackend):
             name (str): the name of the file
             local (str): if set the local path will be created and the file
                stored there. If local does not have an extension it is assumed
-               to be a directory name, in which case the file is stored as the
-               same name.
+               to be a directory name, where the file will stored with /path/to/local/name.
+               If the directory does not exist, the directory is created.
             mode (str): the mode to use on .open() for the local file
             chunksize (int): optional, the size of chunks to be read, as in
-            open_kwargs (dict): the kwargs to use .open() for the local file
+            open_kwargs (dict): optional, the kwargs to use .open() for the local file
+            uri (str): optional, a uri passed to smart_open for the source location of the file.
+              If not specified, defaults to metadata.uri, which defaults to metadata.gridfile
+            extract (bool): optional, defaults to False. If True and the file is a zipfile, the file will be
+              extracted to the local= path. Defaults to True if local is a directory or if
+              uri exists as a local path; in this case uri is the local path.
+            replace (bool): if True, an existing local file will be overwritten
             **kwargs: any kwargs passed to datasets.metadata()
 
         Returns:
@@ -64,21 +78,38 @@ class PythonRawFileBackend(BaseDataBackend):
         """
         meta = self.data_store.metadata(name, **kwargs)
         chunksize = chunksize or 1024 * 1024 * 4
-        uri = uri or meta.uri
+        if uri and Path(uri).parent.exists():
+            local = local or uri
+            extract = True if extract is None else extract
+        else:
+            uri = meta.uri
         if uri:
             outf = open(uri, mode='rb')
         else:
             outf = self.data_store.metadata(name, **kwargs).gridfile
         if local:
-            is_filename = '.' in basename(local)
-            target_dir = dirname(local) if is_filename else local
-            local = local if is_filename else '{local}/{name}'.format(**locals())
-            os.makedirs(target_dir, exist_ok=True)
+            is_filename = not Path(local).is_dir() and (Path(local).is_file() or Path(local).suffix != '')
+            target_dir = dirname(local) if is_filename and not extract else local
+            extract = extract if extract is not None else not is_filename
+            as_file_local = '{local}/{name}'.format(**locals()) if not extract else local
+            local = local if is_filename else as_file_local
             open_kwargs = open_kwargs or {}
-            with smart_open.open(local, mode=mode, **open_kwargs) as flocal:
-                while data := outf.read(chunksize):
-                    flocal.write(data)
-            return local
+            is_zipfile = zipfile.is_zipfile(outf)
+            outf.seek(0)  # ensure we're back to 0 offset after zipfile.is_zipfile()
+            if extract and is_zipfile:
+                if Path(target_dir).is_file():
+                    target_dir = Path(target_dir).with_suffix('.unzipped')
+                    local = target_dir
+                os.makedirs(target_dir, exist_ok=True)
+                with zipfile.ZipFile(outf) as zip:
+                    zip.extractall(path=target_dir)
+            elif replace or not Path(local).exists():
+                with smart_open.open(local, mode=mode, **open_kwargs) as flocal:
+                    while data := outf.read(chunksize):
+                        flocal.write(data)
+            else:
+                logger.warning(f'{local} exists already, no data written')
+            return Path(local)
         return filelike(outf)
 
     def put(self, obj, name, attributes=None, encoding=None, uri=None, **kwargs):

--- a/omegaml/client/cli/models.py
+++ b/omegaml/client/cli/models.py
@@ -9,6 +9,7 @@ class ModelsCommandBase(StoresCommandMixin, CommandBase):
     """
     Usage:
       om models list [<pattern>] [--raw] [-E|--regexp] [options]
+      om models get <name> <path>
       om models put <spec> <name>
       om models drop <name>
       om models metadata <name>
@@ -18,18 +19,30 @@ class ModelsCommandBase(StoresCommandMixin, CommandBase):
 
     .. versionchanged:: 0.18.0
          om models put <spec> <name> now supports arbitrary model specifications
+
+    .. versionchanged:: NEXT
+        om models get <name> <path> is the same as om.models.get(name, local='<path>')
     """
     command = 'models'
 
+    def get(self):
+        om = get_omega(self.args)
+        name = self.args.get('<name>')
+        path = self.args.get('<path>')
+        result = om.models.get(name, local=path, replace=True)
+        self.logger.info(result)
+
     def put(self):
         om = get_omega(self.args)
-        modname = self.args.get('<spec>')
+        spec = self.args.get('<spec>')
         name = self.args.get('<name>')
         try:
-            modname, modelfn = modname.rsplit('.', maxsplit=1)
+            modname, modelfn = spec.rsplit('.', maxsplit=1)
             mod = import_module(modname)
             modelfn = getattr(mod, modelfn)
             model = modelfn()
         except:
-            model = modname
-        self.logger.info(om.models.put(model, name))
+            # use
+            model = spec
+        result = om.models.put(model, name)
+        self.logger.info(result)

--- a/omegaml/tests/core/test_store.py
+++ b/omegaml/tests/core/test_store.py
@@ -992,6 +992,26 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(data.encode('utf-8'), store.get('myfile').read())
         self.assertEqual(data.encode('utf-8'), meta.gridfile.read())
 
+    def test_raw_files_local(self):
+        store = self._make_store()
+        # test we can write from a file-like object
+        data = "some data"
+        # saving an open file implicitely
+        file_like = BytesIO(data.encode('utf-8'))
+        meta = store.put(file_like, 'myfile')
+        localFile = Path('/tmp/myfile')
+        # local file does not exist already
+        localFile.unlink(missing_ok=True)
+        store.get('myfile', local=localFile)
+        with open(localFile, 'r') as fin:
+            data_ = fin.read()
+            self.assertEqual(data_, data)
+        # localFile exists already
+        store.get('myfile', local=localFile, replace=True)
+        with open(localFile, 'r') as fin:
+            data_ = fin.read()
+            self.assertEqual(data_, data)
+
     def test_raw_files_uri(self):
         store = self._make_store()
         # test we can write from a file-like object to uri


### PR DESCRIPTION
- py: om.models.get(name, local='/path/to/file.ext') will write the gridfile to local file, from python
- cli: om models get <name> </path/to/file.ext> will write the gridfile to local file from, from the cli