### PR TITLE
fix: oci repository does not support multiple model versions

### DIFF
--- a/omegaml/backends/basemodel.py
+++ b/omegaml/backends/basemodel.py
@@ -188,8 +188,8 @@ class BaseModelBackend(BackendBaseCommon):
                         raise ValueError(f'no {self._magictgz} file found')
             except (tarfile.TarError, ValueError):
                 return False
-            infile.open()
-            infile.seek(0)
+            infile.open() if hasattr(infile, 'open') else None
+            infile.seek(0) if hasattr(infile, 'seek') else None
             return True
 
         if is_omegaml_tgz(infile):

--- a/omegaml/mixins/store/extdmeta.py
+++ b/omegaml/mixins/store/extdmeta.py
@@ -507,7 +507,7 @@ class DatasetIndexesMixin:
     and consistent recreation.
 
     Metadata:
-        * ``.attributes['indexes']`` → ``{'<key>': <sort order>}``
+        * ``.attributes['indexes']`` => ``{'<key>': <sort order>}``
 
     .. versionadded:: NEXT
         Enable consistent indexes specification in metadata.

--- a/omegaml/mixins/store/repository.py
+++ b/omegaml/mixins/store/repository.py
@@ -43,16 +43,21 @@ class RepositoryStorageMixin:
             reg: ArtifactRepository = self.get(repo, image=image)
             assert reg is not None, f"repository {repo} not found in {self.prefix}"
             # create directory to export to
-            repo_uri = Path(f'{self.tmppath}/{self.prefix}')  # repo files
-            obj_uri = Path(f'{self.tmppath}/{self.prefix}') / 'modelfile.rps'  # serialized model
+            key = self.object_store_key(name, 'serialized')
+            repo_uri = Path(f'{self.tmppath}/{key}')  # repo files
+            obj_uri = repo_uri / 'modelfile.rps'  # serialized model
             rmtree(repo_uri, ignore_errors=True)
-            obj_uri.parent.mkdir(parents=True, exist_ok=True)
+            repo_uri.mkdir(parents=True, exist_ok=True)
             # serialize obj to a local file, using original backend
             # -- uri= stores file to path obj_uri, instead of gridfile
             # -- repo=False ensures we're not getting called twice accidentally
             kwargs.update(uri=obj_uri, repo=False)
-            backend = self.get_backend_byobj(obj, **kwargs)  # type: BaseModelBackend
-            # target_repo = reg.tag(repo, next=True)  # get next tag (v1, v2, ...)
+            if not meta:
+                backend = self.get_backend_byobj(obj, **kwargs)  # type: BaseModelBackend
+            else:
+                backend = self.get_backend(name, **kwargs)  # type: BaseModelBackend
+            # TODO get next tag (v1, v2, ...)
+            # target_repo = reg.tag(repo, next=True)
             meta = backend.put(obj, name, **kwargs)
             meta.uri = ''  # uri is only for temporary storage
             sync = meta.attributes.setdefault('sync', sync)
@@ -61,9 +66,9 @@ class RepositoryStorageMixin:
             image, tag = image.split(':') if ':' in image else (image, 'latest')
             target_repo = f'{image}:{tag}'
             sync['repo'] = f'{repo}/{target_repo}'
-            with chdir(obj_uri.parent):
+            with chdir(repo_uri):
                 reg.add(obj_repo_uri, repo=target_repo)  # add to repo
-            rmtree(obj_uri.parent, ignore_errors=True)
+            rmtree(repo_uri, ignore_errors=True)
         else:
             meta = super().put(obj, name, *args, **kwargs)
         return meta.save()
@@ -79,9 +84,10 @@ class RepositoryStorageMixin:
             repo, image = repo.rsplit('/', 1) if '/' in repo else (repo, name)
             reg: ArtifactRepository = self.get(repo)
             # TODO repo_uri / obj_uri come from ArtifactRepository to use its cache
-            repo_uri = Path(f'{self.tmppath}/{self.prefix}')  # repo files
-            obj_uri = Path(f'{self.tmppath}/{self.prefix}') / 'modelfile.rps'  # serialized model
-            rmtree(obj_uri.parent, ignore_errors=True)
+            key = self.object_store_key(name, 'serialized')
+            repo_uri = Path(f'{self.tmppath}/{key}')  # repo files
+            obj_uri = repo_uri / 'modelfile.rps'  # serialized model
+            rmtree(repo_uri, ignore_errors=True)
             # source_repo = reg.tag(repo)  # get latest tag, if not specified
             reg.extract(repo_uri, repo=image)  # pull repo and extract to it
             backend = self.get_backend(name, **kwargs)  # type: BaseModelBackend

--- a/omegaml/tests/repository/test_ocireg.py
+++ b/omegaml/tests/repository/test_ocireg.py
@@ -237,6 +237,79 @@ class TestOCIRegistryBackend(OmegaTestMixin, TestCase):
         self.assertEqual(reg.url, 'oci://ghcr.io')
         self.assertEqual(reg.auth, ('myuser', 'myapikey'))
 
+    def test_putget_model_versions(self):
+        om = self.om
+        # create an empty oci registry
+        rmtree('/tmp/registry', ignore_errors=True)
+        om.models.put('ocidir:///tmp/registry', 'ocireg')
+        model = LinearRegression()
+        meta1 = om.models.put(model, 'regmodel', repo='ocireg')
+        meta2 = om.models.put(model, 'regmodel', repo='ocireg')
+        # check gridfile is empty, model is stored in registry
+        reg = om.models.get('ocireg')
+        self.assertEqual(meta1.gridfile.read(), None)
+        self.assertEqual(len(reg.artifacts(repo='regmodel:latest')), 1)
+        # check metadata
+        self.assertIn('sync', meta1.attributes)
+        self.assertEqual(meta2.attributes['sync']['repo'], 'ocireg/regmodel:latest')
+        # get model back from oci registry
+        model = om.models.get('regmodel')
+        self.assertIsInstance(model, LinearRegression)
+
+    def test_transformer_repo(self):
+        import torch
+        from sentence_transformers import CrossEncoder
+        model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L6-v2", activation_fn=torch.nn.Sigmoid())
+
+        from omegaml.backends.virtualobj import virtualobj
+
+        @virtualobj
+        def transformers(obj=None, name=None, meta=None, method=None, store=None, uri=None, **kwargs):
+            print("transformers helper", method, store, kwargs)
+
+            if method == 'put':
+                def serializer(store, model, filename, **kwargs):
+                    print('serializer', kwargs)
+                    model.save_pretrained(str(filename))
+
+                # -- uri is for repo support
+                # -- helper=False avoids recursion
+                return store.put(obj, name, kind='python.model', serializer=serializer, uri=uri, helper=False)
+
+            if method == 'get':
+                def loader(store, infile, filename=None, **kwargs):
+                    print('loader', infile, filename, kwargs)
+                    from sentence_transformers import CrossEncoder
+                    model = CrossEncoder(str(filename))
+                    return model
+
+                # -- helper=False avoids recursion
+                return store.get(name, kind='python.model', loader=loader, helper=False)
+
+        om = self.om
+        om.models.put(transformers, 'helpers/transformers', replace=True)
+        om.models.put('ocidir:///tmp/myrepo', 'myrepo', replace=True)
+        # first time there is no meta for mymodel
+        # 1. helper virtualobj gets called
+        # 2. calls VirtualObjHelper.put()
+        # 3. from within virtualobj calls RepositoryMixin.put() again
+        # 4. there is no meta, and hence no repo => calls GenericModelBackend (due to model=python.model)
+        meta = om.models.put(model, 'mymodel', helper='helpers/transformers', replace=True, repo='myrepo')
+        self.assertEqual(meta.kind, 'python.model')
+        model_ = om.models.get('mymodel')
+        self.assertIsInstance(model_, CrossEncoder)
+        # second time, there *is* a meta for mymodel
+        # -- (replace does not get handled)
+        # -- steps 1 to 3 are the same (correct)
+        # -- step 4 since there is a meta, it will use the explicit backend of the object, not the mixin hierarchy
+        #    => thus we have to drop the model first (FIXME replace=True should do the trick, but is not processed)
+        #    => if we don't drop first, we'll end up with an endless recursion due to super().put() keeps ending up in helper
+        om.models.drop('mymodel', force=True)
+        meta = om.models.put(model, 'mymodel', helper='helpers/transformers', repo='myrepo')
+        self.assertEqual(meta.kind, 'python.model')
+        model_ = om.models.get('mymodel')
+        self.assertIsInstance(model_, CrossEncoder)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/local/Procfile
+++ b/scripts/local/Procfile
@@ -4,3 +4,4 @@ notebook: om shell jupyter
 jupyterhub: jupyterhub --ip 0.0.0.0 --config /etc/jupyterhub/jupyterhub_config.py
 restapi: python -m omegaml.server.restapi
 server:  python -m omegaml.server
+


### PR DESCRIPTION
- fix to avoid call recursion when using a helper and saving multiple versions of a model
- particular cases can still cause recursions, drop model before saving
- adds test for demonstration